### PR TITLE
Fix scoring modules and API

### DIFF
--- a/compute/dii.py
+++ b/compute/dii.py
@@ -1,3 +1,6 @@
+import math
+
+import numpy as np
 import pandas as pd
 
 from compute.base import load_parameters, validate_dataframe
@@ -6,6 +9,11 @@ from compute.base import load_parameters, validate_dataframe
 dii_params = load_parameters("dii_parameters.json")
 # Expose parameter keys for API validation
 DII_PARAMETER_KEYS = [p["name"] for p in dii_params]
+
+
+def get_dii_parameters() -> list:
+    """Return the loaded DII parameter definitions."""
+    return dii_params
 
 
 def calculate_dii(df: pd.DataFrame) -> pd.Series:
@@ -38,9 +46,9 @@ def calculate_dii(df: pd.DataFrame) -> pd.Series:
         sd = param.get("sd")
         effect = param.get("effect")
 
-        x = df[name]
+        x = df[name].fillna(mean)
         z = (x - mean) / sd
-        pct = z.rank(pct=True)
+        pct = 0.5 * (1 + np.vectorize(math.erf)(z / math.sqrt(2)))
         cp = 2 * pct - 1
         score += cp * effect
 

--- a/compute/dii_parameters.json
+++ b/compute/dii_parameters.json
@@ -21,7 +21,7 @@
     "effect": -0.365
   },
   {
-    "name": "b-Carotene",
+    "name": "Beta-carotene",
     "unit": "mg",
     "mean": 3718,
     "sd": 1720,
@@ -42,7 +42,7 @@
     "effect": 0.097
   },
   {
-    "name": "Cholesterol",
+    "name": "Cholesterol ",
     "unit": "mg",
     "mean": 279.4,
     "sd": 51.2,
@@ -70,7 +70,7 @@
     "effect": 0.298
   },
   {
-    "name": "Fibre",
+    "name": "Fiber",
     "unit": "g",
     "mean": 18.8,
     "sd": 4.9,
@@ -98,14 +98,14 @@
     "effect": -0.453
   },
   {
-    "name": "Fe",
+    "name": "Iron",
     "unit": "mg",
     "mean": 13.35,
     "sd": 3.71,
     "effect": 0.032
   },
   {
-    "name": "Mg",
+    "name": "Magnesium",
     "unit": "mg",
     "mean": 310.1,
     "sd": 139.4,
@@ -126,14 +126,14 @@
     "effect": -0.246
   },
   {
-    "name": "n-3 Fatty acids",
+    "name": "n-3 fatty acid",
     "unit": "g",
     "mean": 1.06,
     "sd": 1.06,
     "effect": -0.436
   },
   {
-    "name": "n-6 Fatty acids",
+    "name": "n-6 fatty acid",
     "unit": "g",
     "mean": 10.8,
     "sd": 7.5,
@@ -182,7 +182,7 @@
     "effect": 0.373
   },
   {
-    "name": "Se",
+    "name": "Selenium",
     "unit": "mg",
     "mean": 67.0,
     "sd": 25.1,
@@ -238,7 +238,7 @@
     "effect": -0.419
   },
   {
-    "name": "Zn",
+    "name": "Zinc",
     "unit": "mg",
     "mean": 9.84,
     "sd": 2.19,
@@ -273,7 +273,7 @@
     "effect": -0.467
   },
   {
-    "name": "Flavanones",
+    "name": "Flavonones",
     "unit": "mg",
     "mean": 11.7,
     "sd": 3.82,

--- a/compute/mind.py
+++ b/compute/mind.py
@@ -25,6 +25,9 @@ _MIND_COMPONENTS = [
     {"col": "fried_food_servings", "type": "unhealthy", "high": 1, "med": 3},
 ]
 
+# Export just the column names for API validation
+MIND_COMPONENT_KEYS = [c["col"] for c in _MIND_COMPONENTS]
+
 
 def calculate_mind(df: pd.DataFrame) -> pd.Series:
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for module imports
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- implement missing helper for DII parameters
- add constant list for MIND diet keys
- align DII parameter names to validation CSV
- update DII algorithm for missing values and correct percentile
- return JSON from `/score` and add download endpoint
- relax API required columns and default to DII only
- ensure tests run by adjusting `sys.path`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f1e0c74b4833388ebd43861ccdfb8