### PR TITLE
Improve web UI and fix DII parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ cd dietary-index-web
 
 - Static UI served at: [http://localhost:8000](http://localhost:8000)
 - API documentation (Swagger) at: [http://localhost:8000/docs](http://localhost:8000/docs) when in `--dev` mode.
+- The web UI defaults to this local address. Use the "API URL" field in the page to point to a different backend when hosted elsewhere.
 
 ---
 

--- a/compute/dii_parameters.json
+++ b/compute/dii_parameters.json
@@ -42,7 +42,7 @@
     "effect": 0.097
   },
   {
-    "name": "Cholesterol ",
+    "name": "Cholesterol",
     "unit": "mg",
     "mean": 279.4,
     "sd": 51.2,

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
   <script src="https://cdn.plot.ly/plotly-2.32.0.min.js"></script>
   <style>
     :root {
@@ -73,6 +74,13 @@
       margin-top: 0.5rem;
       font-size: 0.9rem;
     }
+    #previewContainer {
+      overflow-x: auto;
+      margin-top: 1rem;
+    }
+    #previewTable {
+      min-width: 600px;
+    }
     th, td {
       padding: 0.5rem;
       border: 1px solid var(--border);
@@ -93,15 +101,24 @@
   </style>
 </head>
 <body>
-  <div class="container">
+  <div class="container my-4">
     <h1>Dietary Index Calculator</h1>
-    <div class="controls">
-      <label><input type="checkbox" value="DII" checked /> DII</label>
-      <label><input type="checkbox" value="MIND" checked /> MIND</label>
-      <label><input type="checkbox" value="HEI_2015" checked /> HEI‑2015</label>
-      <label><input type="checkbox" value="DASH" checked /> DASH</label>
+    <div class="controls d-flex flex-wrap gap-2 align-items-center mb-3">
+      <label class="form-check">
+        <input class="form-check-input" type="checkbox" value="DII" checked /> DII
+      </label>
+      <label class="form-check">
+        <input class="form-check-input" type="checkbox" value="MIND" checked /> MIND
+      </label>
+      <label class="form-check">
+        <input class="form-check-input" type="checkbox" value="HEI_2015" checked /> HEI‑2015
+      </label>
+      <label class="form-check">
+        <input class="form-check-input" type="checkbox" value="DASH" checked /> DASH
+      </label>
+      <input id="apiBase" class="form-control form-control-sm ms-auto" style="max-width:240px" value="http://localhost:8000" />
     </div>
-    <div id="dropzone">Drag & drop CSV here, or click to select file</div>
+    <div id="dropzone" class="mb-3">Drag & drop CSV here, or click to select file</div>
     <div id="previewContainer">
       <h3 id="previewTitle" style="display:none;">Preview (first 5 rows)</h3>
       <table id="previewTable"></table>
@@ -116,6 +133,9 @@
     const previewTable = document.getElementById('previewTable');
     const previewTitle = document.getElementById('previewTitle');
     const loading = document.getElementById('loading');
+    const apiBaseInput = document.getElementById('apiBase');
+
+    const apiUrl = (path) => apiBaseInput.value.replace(/\/+$/, '') + path;
 
     function quantile(arr, q) {
       const sorted = arr.slice().sort((a, b) => a - b);
@@ -151,15 +171,16 @@
       if (e.dataTransfer.files.length) handleFile(e.dataTransfer.files[0]);
     });
 
-    // Load bundled template on startup for a quick demo
+    // Load bundled template on startup when API is reachable
     window.addEventListener('DOMContentLoaded', async () => {
       try {
+        await fetch(apiUrl('/ping'));
         const res = await fetch('assets/template.csv');
         const blob = await res.blob();
         const file = new File([blob], 'template.csv', { type: 'text/csv' });
         handleFile(file);
       } catch (err) {
-        console.warn('Unable to load sample template:', err);
+        console.warn('API unreachable, skipping demo:', err);
       }
     });
 
@@ -191,8 +212,12 @@
       try {
         const fd = new FormData();
         fd.append('file', file);
-        const res = await fetch(`http://localhost:8000/score?${params}`, { method: 'POST', body: fd });
-        if (!res.ok) throw new Error((await res.json()).detail);
+        const res = await fetch(apiUrl(`/score?${params}`), { method: 'POST', body: fd });
+        if (!res.ok) {
+          let detail = '';
+          try { detail = (await res.json()).detail; } catch {}
+          throw new Error(detail || `Server error ${res.status}`);
+        }
         const blob = await res.blob();
         const csvText = await blob.text();
         const data = csvText.trim().split('\n').map(r => r.split(','));
@@ -216,7 +241,7 @@
         URL.revokeObjectURL(url);
       } catch(err) {
         console.error(err);
-        resultBox.innerHTML = `<div class='error'>${err.message}</div>`;
+        resultBox.innerHTML = `<div class='error'>${err.message}. Check API at ${apiBaseInput.value}</div>`;
       } finally {
         loading.style.display = 'none';
       }


### PR DESCRIPTION
## Summary
- tweak index.html layout with Bootstrap
- let the API base URL be configurable in the UI
- improve error details on failed fetch
- load sample only when API is reachable
- clean up preview table layout
- fix trailing space in DII parameter list
- document API URL field in README

## Testing
- `pytest -q`
- `pre-commit run --files index.html compute/dii_parameters.json README.md`

------
https://chatgpt.com/codex/tasks/task_b_685f392733288333a4bd24f1c71e8559