### PR TITLE
Improve API handling and add HTML lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,10 @@ repos:
       - id: trailing-whitespace
       - id: check-added-large-files
         exclude: 'detailed_dii_table_20240606\.csv$'
+
+  - repo: https://github.com/djlint/djlint
+    rev: v1.36.4
+    hooks:
+      - id: djlint
+        args: ['--check']
+        files: '\.html$'

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ cd dietary-index-web
 
 - Static UI served at: [http://localhost:8000](http://localhost:8000)
 - API documentation (Swagger) at: [http://localhost:8000/docs](http://localhost:8000/docs) when in `--dev` mode.
+- The web UI defaults to this local address. Use the "API URL" field in the page to point to a different backend when hosted elsewhere. You can also append `?api=https://yourserver` to the page URL to pre-fill this field.
+- Your chosen API URL is remembered in local storage so you only set it once.
 
 ---
 

--- a/compute/dii_parameters.json
+++ b/compute/dii_parameters.json
@@ -42,7 +42,7 @@
     "effect": 0.097
   },
   {
-    "name": "Cholesterol ",
+    "name": "Cholesterol",
     "unit": "mg",
     "mean": 279.4,
     "sd": 51.2,

--- a/index.html
+++ b/index.html
@@ -1,14 +1,17 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Dietary Index Calculator</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
-  <script src="https://cdn.plot.ly/plotly-2.32.0.min.js"></script>
-  <style>
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Dietary Index Calculator</title>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap"
+              rel="stylesheet" />
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
+              rel="stylesheet" />
+        <script src="https://cdn.plot.ly/plotly-2.32.0.min.js"></script>
+        <style>
     :root {
       --bg: #f9fafb;
       --text: #212529;
@@ -73,6 +76,13 @@
       margin-top: 0.5rem;
       font-size: 0.9rem;
     }
+    #previewContainer {
+      overflow-x: auto;
+      margin-top: 1rem;
+    }
+    #previewTable {
+      min-width: 600px;
+    }
     th, td {
       padding: 0.5rem;
       border: 1px solid var(--border);
@@ -90,32 +100,63 @@
       font-weight: 600;
     }
     .error { color: #d9534f; font-weight: bold; }
-  </style>
-</head>
-<body>
-  <div class="container">
-    <h1>Dietary Index Calculator</h1>
-    <div class="controls">
-      <label><input type="checkbox" value="DII" checked /> DII</label>
-      <label><input type="checkbox" value="MIND" checked /> MIND</label>
-      <label><input type="checkbox" value="HEI_2015" checked /> HEI‑2015</label>
-      <label><input type="checkbox" value="DASH" checked /> DASH</label>
-    </div>
-    <div id="dropzone">Drag & drop CSV here, or click to select file</div>
-    <div id="previewContainer">
-      <h3 id="previewTitle" style="display:none;">Preview (first 5 rows)</h3>
-      <table id="previewTable"></table>
-    </div>
-    <div id="loading">⏳ Scoring in progress...</div>
-    <div id="result"></div>
-    <div id="charts"></div>
-  </div>
-  <script>
+        </style>
+    </head>
+    <body>
+        <div class="container my-4">
+            <h1>Dietary Index Calculator</h1>
+            <div class="controls d-flex flex-wrap gap-2 align-items-center mb-3">
+                <label class="form-check">
+                    <input class="form-check-input" type="checkbox" value="DII" checked />
+                    DII
+                </label>
+                <label class="form-check">
+                    <input class="form-check-input" type="checkbox" value="MIND" checked />
+                    MIND
+                </label>
+                <label class="form-check">
+                    <input class="form-check-input" type="checkbox" value="HEI_2015" checked />
+                    HEI‑2015
+                </label>
+                <label class="form-check">
+                    <input class="form-check-input" type="checkbox" value="DASH" checked />
+                    DASH
+                </label>
+                <input id="apiBase"
+                       class="form-control form-control-sm ms-auto"
+                       style="max-width:240px"
+                       placeholder="http://localhost:8000" />
+            </div>
+            <div id="dropzone" class="mb-3">Drag & drop CSV here, or click to select file</div>
+            <div id="previewContainer">
+                <h3 id="previewTitle" style="display:none;">Preview (first 5 rows)</h3>
+                <table id="previewTable">
+                </table>
+            </div>
+            <div id="loading">⏳ Scoring in progress...</div>
+            <div id="result"></div>
+            <div id="charts"></div>
+        </div>
+        <script>
     const dropzone = document.getElementById('dropzone');
     const resultBox = document.getElementById('result');
     const previewTable = document.getElementById('previewTable');
     const previewTitle = document.getElementById('previewTitle');
     const loading = document.getElementById('loading');
+    const apiBaseInput = document.getElementById('apiBase');
+    const paramsQP = new URLSearchParams(location.search);
+    const storedApi = localStorage.getItem('apiBase');
+    if (paramsQP.get('api')) {
+      apiBaseInput.value = paramsQP.get('api');
+    } else if (storedApi) {
+      apiBaseInput.value = storedApi;
+    }
+    apiBaseInput.addEventListener('change', () => {
+      localStorage.setItem('apiBase', apiBaseInput.value);
+    });
+
+    const apiUrl = (path) =>
+      (apiBaseInput.value || 'http://localhost:8000').replace(/\/+$/, '') + path;
 
     function quantile(arr, q) {
       const sorted = arr.slice().sort((a, b) => a - b);
@@ -151,15 +192,16 @@
       if (e.dataTransfer.files.length) handleFile(e.dataTransfer.files[0]);
     });
 
-    // Load bundled template on startup for a quick demo
+    // Load bundled template on startup when API is reachable
     window.addEventListener('DOMContentLoaded', async () => {
       try {
+        await fetch(apiUrl('/ping'));
         const res = await fetch('assets/template.csv');
         const blob = await res.blob();
         const file = new File([blob], 'template.csv', { type: 'text/csv' });
         handleFile(file);
       } catch (err) {
-        console.warn('Unable to load sample template:', err);
+        console.warn('API unreachable, skipping demo:', err);
       }
     });
 
@@ -191,8 +233,12 @@
       try {
         const fd = new FormData();
         fd.append('file', file);
-        const res = await fetch(`http://localhost:8000/score?${params}`, { method: 'POST', body: fd });
-        if (!res.ok) throw new Error((await res.json()).detail);
+        const res = await fetch(apiUrl(`/score?${params}`), { method: 'POST', body: fd });
+        if (!res.ok) {
+          let detail = '';
+          try { detail = (await res.json()).detail; } catch {}
+          throw new Error(detail || `Server error ${res.status}`);
+        }
         const blob = await res.blob();
         const csvText = await blob.text();
         const data = csvText.trim().split('\n').map(r => r.split(','));
@@ -216,11 +262,11 @@
         URL.revokeObjectURL(url);
       } catch(err) {
         console.error(err);
-        resultBox.innerHTML = `<div class='error'>${err.message}</div>`;
+        resultBox.innerHTML = `<div class='error'>${err.message}. Check API at ${apiBaseInput.value}</div>`;
       } finally {
         loading.style.display = 'none';
       }
     }
-  </script>
-</body>
+        </script>
+    </body>
 </html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyodide-http
 fastapi
 uvicorn
 python-multipart
+httpx


### PR DESCRIPTION
## Summary
- remember API URL in local storage and use placeholder instead of default value
- fall back to localhost only when field empty
- lint HTML via djlint in pre-commit
- document API URL persistence
- add httpx dependency for tests

## Testing
- `pre-commit run --files index.html README.md .pre-commit-config.yaml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685f392733288333a4bd24f1c71e8559