### PR TITLE
Remove pyodide-http from deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 numpy
 pandas
 pytest
-pyodide-http
 fastapi
 uvicorn
 python-multipart


### PR DESCRIPTION
## Summary
- drop `pyodide-http` from `requirements.txt`
- update lock file references

## Testing
- `pre-commit run --files requirements.txt setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f576d0e14833384284a00faf88aa3