### PR TITLE
Fix server connection and auto-run setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,13 +22,14 @@ COPY tests/ tests/
 COPY index.html index.html
 COPY assets/ assets/
 COPY docs/ docs/
+COPY setup.sh setup.sh
 
 # Disable Python bytecode, enable logs
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
-# Expose port for static HTML hosting
+# Expose port for API + frontend
 EXPOSE 8000
 
-# Default CMD serves index.html from repository root
-CMD ["python3", "-m", "http.server", "8000", "--directory", "."]
+# Run setup script on container start
+CMD ["bash", "./setup.sh"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -15,4 +15,5 @@ RUN pip install uvicorn fastapi[all] watchdog
 COPY . .
 
 EXPOSE 8000
-CMD ["uvicorn", "compute.api:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+COPY setup.sh setup.sh
+CMD ["bash", "./setup.sh", "--dev"]

--- a/compute/api.py
+++ b/compute/api.py
@@ -8,7 +8,8 @@ from uuid import uuid4
 import pandas as pd
 from fastapi import FastAPI, File, HTTPException, Query, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
+from fastapi.staticfiles import StaticFiles
 
 from compute.dash import DASH_COMPONENT_KEYS, calculate_dash
 from compute.dii import calculate_dii, get_dii_parameters
@@ -43,6 +44,17 @@ app = FastAPI(
     description=("Score multiple diet-quality indices from uploaded nutrition data."),
     version="0.1.0",
 )
+
+# Serve the frontend assets when running the API directly
+BASE_DIR = Path(__file__).resolve().parent.parent
+app.mount("/assets", StaticFiles(directory=BASE_DIR / "assets"), name="assets")
+
+
+@app.get("/", include_in_schema=False)
+def read_index():
+    """Return the main HTML page."""
+    return FileResponse(BASE_DIR / "index.html")
+
 
 # Enable CORS for local dev; lock down origins in production
 app.add_middleware(

--- a/index.html
+++ b/index.html
@@ -221,7 +221,7 @@
         if (!ping.ok) {
           console.warn('API ping not OK', ping.status, ping.statusText);
         }
-  
+
       } catch (err) {
         console.warn('API ping failed', err);
         const msg = err instanceof Error ? err.message : String(err);
@@ -279,7 +279,7 @@
         if (!res.ok) {
           let detail = '';
           try { detail = (await res.json()).detail; } catch {}
-          
+
           if (!detail) {
             const text = await res.text().catch(() => '');
             detail = text.trim();

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@
 
 set -e
 
-MODE="basic"
+MODE="prod"
 if [[ "$1" == "--dev" ]]; then
   MODE="dev"
 fi
@@ -26,12 +26,11 @@ pre-commit install
 echo "🧪 Running tests..."
 pytest tests || echo "⚠️ Some tests failed — check test output above."
 
+echo "🚀 Starting FastAPI backend..."
+pip install uvicorn 'fastapi[all]' watchdog
 if [[ "$MODE" == "dev" ]]; then
-  echo "🚀 Starting FastAPI dev backend with live reload..."
-  pip install uvicorn 'fastapi[all]' watchdog
-  uvicorn compute.api:app --host 0.0.0.0 --port 8000 --reload
+  EXTRA="--reload"
 else
-  echo "🌐 Starting local frontend server..."
-  python3 -m http.server 8000 &
-  echo "✅ Setup complete. Visit http://localhost:8000"
+  EXTRA=""
 fi
+uvicorn compute.api:app --host 0.0.0.0 --port 8000 $EXTRA


### PR DESCRIPTION
## Summary
- serve frontend static files directly from FastAPI
- start FastAPI from `setup.sh` for both prod/dev
- ensure Dockerfiles run setup script on launch
- trim trailing whitespace in index.html

## Testing
- `pre-commit run --files compute/api.py setup.sh Dockerfile Dockerfile.dev index.html`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f5f96aa98833399707a555ecc7b97