### PR TITLE
Enable backendless scoring via Pyodide

### DIFF
--- a/.codexrc
+++ b/.codexrc
@@ -1,5 +1,5 @@
 # Configuration for Codex agent to understand project structure
-project: dietary-index-web
+project: dietarycodex
 language: python
 entrypoints:
   - index.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,4 @@ jobs:
           pytest tests
 
       - name: 🐳 Build Docker
-        run: docker build -t dietary-index-web .
+        run: docker build -t dietarycodex .

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dietary Index Web Calculator
 
-**A browser-based tool for computing multiple diet-quality scores (DII, MIND, HEI‑2015, DASH) from nutrition CSV data**.
+**A browser-based tool for computing multiple diet-quality scores (DII, MIND, HEI‑2015, DASH) from nutrition CSV data**. The GitHub Pages site uses Pyodide so it works without any backend server.
 
 ---
 
@@ -8,9 +8,9 @@
 
 ```bash
 # Clone the repo
-git clone https://github.com/<your-fork>/dietary-index-web.git
+git clone https://github.com/<your-fork>/dietarycodex.git
 # Change directory
-cd dietary-index-web
+cd dietarycodex
 
 # Install dependencies and start the local frontend
 ./setup.sh
@@ -31,7 +31,7 @@ cd dietary-index-web
 
 ### GitHub Pages Usage
 
-When the static site is served from `*.github.io`, there is **no backend API** available by default. Enter the URL of your running FastAPI service in the "API URL" field or append `?api=<url>` to the page. The page will display a warning until a reachable API is configured.
+The live site at [https://dgd-strategies.github.io/dietarycodex](https://dgd-strategies.github.io/dietarycodex) runs entirely in your browser using Pyodide. No server setup is required—just open the link and start scoring CSV files. The local setup script remains available for development or running your own FastAPI backend.
 
 ---
 

--- a/contributing.md
+++ b/contributing.md
@@ -9,8 +9,8 @@ Thank you for your interest in contributing! This guide outlines the workflow, s
 1. **Fork** the repository to your personal GitHub account.
 2. **Clone** your fork:
    ```bash
-   git clone https://github.com/<your-username>/dietary-index-web.git
-   cd dietary-index-web
+   git clone https://github.com/<your-username>/dietarycodex.git
+   cd dietarycodex
    ```
 3. **Install** dependencies and set up your environment:
    ```bash

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
               rel="stylesheet" />
         <script src="https://cdn.plot.ly/plotly-2.32.0.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/pyodide/v0.25.1/full/pyodide.js"></script>
         <style>
     :root {
       --bg: #f9fafb;
@@ -165,6 +166,28 @@
       localStorage.setItem('apiBase', apiBaseInput.value);
     });
 
+    const isGH = location.hostname.endsWith('github.io');
+    let pyReady = null;
+    async function loadPy() {
+      if (!pyReady) {
+        pyReady = loadPyodide({ indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.25.1/full/' })
+          .then(async py => {
+            await py.loadPackage(['pandas', 'numpy']);
+            const files = ['base.py','dii.py','dash.py','mind.py','hei.py','dii_parameters.json'];
+            for (const f of files) {
+              const resp = await fetch('./compute/' + f);
+              const text = await resp.text();
+              const dir = '/tmp/compute';
+              try { py.FS.stat(dir); } catch { py.FS.mkdirTree(dir); }
+              py.FS.writeFile(dir + '/' + f, text);
+            }
+            await py.runPythonAsync("import sys; sys.path.insert(0, '/tmp')");
+            return py;
+          });
+      }
+      return pyReady;
+    }
+
     function apiUrl(path) {
       const base = apiBaseInput.value || (!location.hostname.endsWith('github.io') ? location.origin : '');
       return base.replace(/\/+$/, '') + path;
@@ -214,11 +237,13 @@
 
     // Load bundled template on startup
     window.addEventListener('DOMContentLoaded', async () => {
-      const isGH = location.hostname.endsWith('github.io');
       console.log('Using API', apiBaseInput.value || location.origin);
       if (isGH && !apiBaseInput.value) {
-        apiStatus.textContent = 'Static site: enter API URL';
-        apiStatus.className = 'small ms-2 text-warning';
+        apiStatus.textContent = 'Loading Pyodide...';
+        apiStatus.className = 'small ms-2 text-info';
+        await loadPy();
+        apiStatus.textContent = 'Local compute ready';
+        apiStatus.className = 'small ms-2 text-success';
       } else {
         try {
           const ping = await fetch(apiUrl('/ping'));
@@ -278,15 +303,68 @@
       selected.forEach(i => params.append('indices', i));
 
       try {
-        const fd = new FormData();
-        fd.append('file', file);
-        const res = await fetch(apiUrl(`/score?${params}`), {
-          method: 'POST',
-          body: fd,
-        });
-        if (!res.ok) {
-          let detail = '';
-          try { detail = (await res.json()).detail; } catch {}
+        if (isGH && !apiBaseInput.value) {
+          const py = await loadPy();
+          const csvStr = JSON.stringify(text);
+          const pyRes = await py.runPythonAsync(`
+import pandas as pd, io, json
+from compute.dii import calculate_dii
+from compute.mind import calculate_mind
+from compute.hei import calculate_hei_2015
+from compute.dash import calculate_dash
+from compute.base import compute_summary_stats
+csv = ${csvStr}
+df = pd.read_csv(io.StringIO(csv))
+indices = ${JSON.stringify(selected)}
+stats = {}
+if 'DII' in indices:
+    df['DII'] = calculate_dii(df)
+    stats['DII'] = compute_summary_stats(df, ['DII'])['DII']
+if 'MIND' in indices:
+    df['MIND'] = calculate_mind(df)
+    stats['MIND'] = compute_summary_stats(df, ['MIND'])['MIND']
+if 'HEI_2015' in indices:
+    df['HEI_2015'] = calculate_hei_2015(df)
+    stats['HEI_2015'] = compute_summary_stats(df, ['HEI_2015'])['HEI_2015']
+if 'DASH' in indices:
+    df['DASH'] = calculate_dash(df)
+    stats['DASH'] = compute_summary_stats(df, ['DASH'])['DASH']
+out = {'csv': df.to_csv(index=False), 'stats': stats}
+json.dumps(out)
+`);
+          const info = JSON.parse(pyRes);
+          const csvText = info.csv;
+          const data = csvText.trim().split('\n').map(r => r.split(','));
+          const idx = data[0].reduce((m,h,i) => (m[h]=i,m), {});
+          let summary = '<h3>Summary Statistics:</h3><ul>';
+          selected.forEach(name => {
+            const vals = data.slice(1).map(r => parseFloat(r[idx[name]])).filter(v => !isNaN(v));
+            const s = info.stats[name];
+            summary += `<li><b>${name}</b> – mean: ${parseFloat(s.mean).toFixed(2)}, std: ${parseFloat(s.std).toFixed(2)}, min: ${parseFloat(s.min).toFixed(2)}, max: ${parseFloat(s.max).toFixed(2)}, median: ${parseFloat(s.median).toFixed(2)}, quintiles: ${s.quintiles.map(q=>parseFloat(q).toFixed(2)).join(', ')}</li>`;
+            const chartDiv = document.createElement('div');
+            document.getElementById('charts').append(chartDiv);
+            Plotly.newPlot(chartDiv,[{x:vals,type:'histogram',name}],{title:`${name} Distribution`,margin:{t:40}}, {responsive:true});
+          });
+          summary += '</ul>';
+          resultBox.innerHTML = summary;
+          const blob = new Blob([csvText], {type:'text/csv'});
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = file.name.replace(/\.csv$/, '') + '_scores.csv';
+          a.click();
+          URL.revokeObjectURL(url);
+          console.log('Scoring complete via Pyodide');
+        } else {
+          const fd = new FormData();
+          fd.append('file', file);
+          const res = await fetch(apiUrl(`/score?${params}`), {
+            method: 'POST',
+            body: fd,
+          });
+          if (!res.ok) {
+            let detail = '';
+            try { detail = (await res.json()).detail; } catch {}
 
           if (!detail) {
             const text = await res.text().catch(() => '');
@@ -300,33 +378,34 @@
           const statusLine = `HTTP ${res.status} ${res.statusText}`;
           throw new Error(detail ? `${statusLine} - ${detail}` : statusLine);
         }
-        const info = await res.json();
-        const dl = await fetch(apiUrl(`/download/${info.filename}`));
-        if (!dl.ok) {
-          throw new Error(`Download error ${dl.status} ${dl.statusText}`);
+          const info = await res.json();
+          const dl = await fetch(apiUrl(`/download/${info.filename}`));
+          if (!dl.ok) {
+            throw new Error(`Download error ${dl.status} ${dl.statusText}`);
+          }
+          const blob = await dl.blob();
+          const csvText = await blob.text();
+          const data = csvText.trim().split('\n').map(r => r.split(','));
+          const idx = data[0].reduce((m,h,i) => (m[h]=i,m), {});
+          let summary = '<h3>Summary Statistics:</h3><ul>';
+          selected.forEach(name => {
+            const vals = data.slice(1).map(r => parseFloat(r[idx[name]])).filter(v => !isNaN(v));
+            const s = computeStats(vals);
+            summary += `<li><b>${name}</b> – mean: ${s.mean}, std: ${s.std}, min: ${s.min}, max: ${s.max}, median: ${s.median}, quintiles: ${s.quintiles.join(', ')}</li>`;
+            const chartDiv = document.createElement('div');
+            document.getElementById('charts').append(chartDiv);
+            Plotly.newPlot(chartDiv,[{x:vals,type:'histogram',name}],{title:`${name} Distribution`,margin:{t:40}}, {responsive:true});
+          });
+          summary += '</ul>';
+          resultBox.innerHTML = summary;
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = file.name.replace(/\.csv$/, '') + '_scores.csv';
+          a.click();
+          URL.revokeObjectURL(url);
+          console.log('Scoring complete, results downloaded');
         }
-        const blob = await dl.blob();
-        const csvText = await blob.text();
-        const data = csvText.trim().split('\n').map(r => r.split(','));
-        const idx = data[0].reduce((m,h,i) => (m[h]=i,m), {});
-        let summary = '<h3>Summary Statistics:</h3><ul>';
-        selected.forEach(name => {
-          const vals = data.slice(1).map(r => parseFloat(r[idx[name]])).filter(v => !isNaN(v));
-          const s = computeStats(vals);
-          summary += `<li><b>${name}</b> – mean: ${s.mean}, std: ${s.std}, min: ${s.min}, max: ${s.max}, median: ${s.median}, quintiles: ${s.quintiles.join(', ')}</li>`;
-          const chartDiv = document.createElement('div');
-          document.getElementById('charts').append(chartDiv);
-          Plotly.newPlot(chartDiv,[{x:vals,type:'histogram',name}],{title:`${name} Distribution`,margin:{t:40}}, {responsive:true});
-        });
-        summary += '</ul>';
-        resultBox.innerHTML = summary;
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = file.name.replace(/\.csv$/, '') + '_scores.csv';
-        a.click();
-        URL.revokeObjectURL(url);
-        console.log('Scoring complete, results downloaded');
       } catch(err) {
         console.error('Scoring failed', err);
         let msg = err instanceof Error ? `${err.name}: ${err.message}` : String(err);


### PR DESCRIPTION
## Summary
- allow the page to compute scores client side using Pyodide when no API URL is set
- update documentation and metadata to use the new repository name `dietarycodex`
- show link to live GitHub Pages site in README

## Testing
- `pre-commit run --files .codexrc .github/workflows/ci.yml README.md contributing.md index.html`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f69769e70833387d9c988cc8e74ce