### PR TITLE
Update docs and add service worker

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -4,20 +4,25 @@
 This file provides guidance and context to the AI Codex agent when contributing to the DietaryCodex repository.
 
 ## Project Overview
-DietaryCodex is a Python-based FastAPI application that computes multiple diet-quality indices (DII, MIND, HEI-2015, DASH) from uploaded nutrition data. It uses `pandas` for data handling and includes pre-commit checks (`black`, `isort`, `flake8`) and pytest for testing.
+DietaryCodex is a browser-first tool for computing multiple diet-quality indices
+(DII, MIND, HEI‑2015, DASH). The GitHub Pages site runs the Python scoring
+modules through **Pyodide**, so users can upload a CSV and get results with no
+server required. The same modules under `compute/` double as a Python library
+for offline or programmatic use. A minimal FastAPI backend exists only for
+automated tests. Pre-commit checks (`black`, `isort`, `flake8`) and pytest
+provide quality assurance.
 
 ## Directory Structure
 ```
 /
 ├── compute/                # Core computation modules (dii, mind, hei, dash, base)
-├── frontend/               # Front-end static assets (CSS/JS)
 ├── tests/                  # Pytest test suites
 ├── docs/                   # Documentation files (markdown)
 ├── .pre-commit-config.yaml # Pre-commit hooks configuration
 ├── pyproject.toml          # Tool configuration (black, isort, flake8, mypy)
 ├── README.md               # High-level project overview
 └── AGENT.md                # Agent guidance file
-index.html                  # kept in root directy as the page has a static deployment using GitHub Pages
+index.html                  # Single-page app served via GitHub Pages
 ```
 
 ## Coding Standards
@@ -27,17 +32,15 @@ index.html                  # kept in root directy as the page has a static depl
 
 ## Development Workflow
 1. **Clone** the repository.
-2. **Install** dependencies:
+2. **Open** `index.html` directly or serve it with `python -m http.server` to
+   use the browser-only version.
+3. **Install** dependencies (for running tests or the optional library):
    ```bash
    pip install -r requirements.txt
    ```
-3. **Run pre-commit** checks before committing:
+4. **Run pre-commit** checks before committing:
    ```bash
    pre-commit run --all-files
-   ```
-4. **Start server** for local testing:
-   ```bash
-   uvicorn compute.api:app --reload
    ```
 5. **Run tests**:
    ```bash

--- a/README.md
+++ b/README.md
@@ -4,34 +4,11 @@
 
 ---
 
-## Quick Start
+## Using the Web App
 
-```bash
-# Clone the repo
-git clone https://github.com/<your-fork>/dietarycodex.git
-# Change directory
-cd dietarycodex
+Just open [https://dgd-strategies.github.io/dietarycodex](https://dgd-strategies.github.io/dietarycodex) or `index.html` locally. The page works fully client side and registers a service worker providing a demo endpoint `/api/time`.
 
-# Install dependencies and start the local frontend
-./setup.sh
-
-# OR run with the FastAPI backend in dev mode
-./setup.sh --dev
-```
-
-- Static UI served at: [http://localhost:8000](http://localhost:8000)
-- API documentation (Swagger) at: [http://localhost:8000/docs](http://localhost:8000/docs) when in `--dev` mode.
-- The web UI defaults to this local address. Use the "API URL" field in the page to point to a different backend when hosted elsewhere. You can also append `?api=https://yourserver` to the page URL to pre-fill this field.
-- Your chosen API URL is remembered in local storage so you only set it once.
-- The UI shows the API ping status (HTTP code and reason) next to this field on page load.
-- Running `./setup.sh` installs all Python requirements (including `pandas`, `numpy`)
-  and sets up the `pre-commit` tool for linting. The script also installs
-  `shellcheck-py` so the ShellCheck hook works even when Docker is unavailable.
-- Error messages now include HTTP status details when API calls fail.
-
-### GitHub Pages Usage
-
-The live site at [https://dgd-strategies.github.io/dietarycodex](https://dgd-strategies.github.io/dietarycodex) runs entirely in your browser using Pyodide. No server setup is required—just open the link and start scoring CSV files. The local setup script remains available for development or running your own FastAPI backend.
+The optional `setup.sh` script only installs dependencies for tests and the Python library.
 
 ---
 
@@ -39,9 +16,9 @@ The live site at [https://dgd-strategies.github.io/dietarycodex](https://dgd-str
 
 ```
 ├── Dockerfile               # Production Docker image (static frontend)
-├── Dockerfile.dev           # Dev Docker image (FastAPI + reload)
-├── docker-compose.yml       # Mounts code + runs FastAPI / frontend together
-├── setup.sh                 # Local setup script with `--dev` flag
+├── Dockerfile.dev           # Optional dev image for the test API
+├── docker-compose.yml       # Local orchestration for API tests
+├── setup.sh                 # Installs deps and optional API for tests
 ├── requirements.txt         # Python dependencies
 ├── pyproject.toml           # black, isort, flake8, pytest config
 ├── .pre-commit-config.yaml  # Git pre-commit hooks

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,20 +24,16 @@ Welcome to the documentation portal for the **Dietary Index Web Calculator**. Th
 
 ## Overview
 
-The **Dietary Index Web Calculator** is a browser-based tool for computing multiple diet-quality indices (DII, MIND, HEI‑2015, DASH) from user-uploaded nutrition data. It combines a vanilla JS frontend with a Python FastAPI backend.
+The **Dietary Index Web Calculator** lets users compute multiple diet-quality
+indices (DII, MIND, HEI‑2015, DASH) right in the browser. The GitHub Pages site
+ runs the Python scoring modules via **Pyodide**, so no server is required. A
+ minimal FastAPI backend exists only for automated tests.
 
 ---
 
-## Quick Start
+## Using the Web App
 
-1. **Install**
-   ```bash
-   ./setup.sh          # Frontend-only
-   ./setup.sh --dev    # Full dev mode (FastAPI + reload)
-   ```
-2. **Run**
-   - Frontend: http://localhost:8000 (static server)
-   - Backend:  http://localhost:8000/ping, /score, /download
+Open the hosted site or `index.html` locally. A service worker provides a demo `/api/time` endpoint. Everything runs in the browser.
 
 ---
 
@@ -112,7 +108,7 @@ Download the master template for user uploads: [template.csv](../assets/template
 
 - **Formatting & Linting**: `make format`, `make lint`
 - **Testing**: `make test`
-- **Dev Server**: `make dev`
+- **Optional API**: `make dev`
 - **CI**: GitHub Actions runs on push/PR (`.github/workflows/ci.yml`)
 
 ---

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
               rel="stylesheet" />
         <script src="https://cdn.plot.ly/plotly-2.32.0.min.js"></script>
         <script src="https://cdn.jsdelivr.net/pyodide/v0.25.1/full/pyodide.js"></script>
+        <script>if ("serviceWorker" in navigator){navigator.serviceWorker.register("sw.js").catch(()=>{});}</script>
         <style>
     :root {
       --bg: #f9fafb;
@@ -123,11 +124,7 @@
                     <input class="form-check-input" type="checkbox" value="DASH" checked />
                     DASH
                 </label>
-                <input id="apiBase"
-                       class="form-control form-control-sm ms-auto"
-                       style="max-width:240px"
-                       placeholder="http://localhost:8000" />
-                <div id="apiStatus" class="small ms-2"></div>
+                <span id="pyStatus" class="ms-auto small text-info">Loading Pyodide...</span>
             </div>
             <div id="dropzone" class="mb-3">Drag & drop CSV here, or click to select file</div>
             <div id="previewContainer">
@@ -142,6 +139,7 @@
                 <table id="previewTable">
                 </table>
             </div>
+            <button id="scoreBtn" class="btn btn-primary mb-2" disabled>Score & Download</button>
             <div id="loading">⏳ Scoring in progress...</div>
             <div id="result"></div>
             <div id="charts"></div>
@@ -153,20 +151,9 @@
     const previewTitle = document.getElementById('previewTitle');
     const clearBtn = document.getElementById('clearBtn');
     const loading = document.getElementById('loading');
-    const apiBaseInput = document.getElementById('apiBase');
-    const apiStatus = document.getElementById('apiStatus');
-    const paramsQP = new URLSearchParams(location.search);
-    const storedApi = localStorage.getItem('apiBase');
-    if (paramsQP.get('api')) {
-      apiBaseInput.value = paramsQP.get('api');
-    } else if (storedApi) {
-      apiBaseInput.value = storedApi;
-    }
-    apiBaseInput.addEventListener('change', () => {
-      localStorage.setItem('apiBase', apiBaseInput.value);
-    });
-
-    const isGH = location.hostname.endsWith('github.io');
+    const pyStatus = document.getElementById('pyStatus');
+    const scoreBtn = document.getElementById('scoreBtn');
+    let currentFile = null;
     let pyReady = null;
     async function loadPy() {
       if (!pyReady) {
@@ -188,10 +175,6 @@
       return pyReady;
     }
 
-    function apiUrl(path) {
-      const base = apiBaseInput.value || (!location.hostname.endsWith('github.io') ? location.origin : '');
-      return base.replace(/\/+$/, '') + path;
-    }
 
     function quantile(arr, q) {
       const sorted = arr.slice().sort((a, b) => a - b);
@@ -235,32 +218,15 @@
       if (e.dataTransfer.files.length) handleFile(e.dataTransfer.files[0]);
     });
 
+    scoreBtn.addEventListener('click', () => {
+      if (currentFile) computeFile(currentFile);
+    });
+
     // Load bundled template on startup
     window.addEventListener('DOMContentLoaded', async () => {
-      console.log('Using API', apiBaseInput.value || location.origin);
-      if (isGH && !apiBaseInput.value) {
-        apiStatus.textContent = 'Loading Pyodide...';
-        apiStatus.className = 'small ms-2 text-info';
-        await loadPy();
-        apiStatus.textContent = 'Local compute ready';
-        apiStatus.className = 'small ms-2 text-success';
-      } else {
-        try {
-          const ping = await fetch(apiUrl('/ping'));
-          console.log('API ping', ping.status, ping.statusText);
-          apiStatus.textContent = `API ${ping.status} ${ping.statusText}`;
-          apiStatus.className = 'small ms-2 ' + (ping.ok ? 'text-success' : 'text-danger');
-          if (!ping.ok) {
-            console.warn('API ping not OK', ping.status, ping.statusText);
-          }
-
-        } catch (err) {
-          console.warn('API ping failed', err);
-          const msg = err instanceof Error ? err.message : String(err);
-          apiStatus.textContent = `API ping failed: ${msg}`;
-          apiStatus.className = 'small ms-2 text-danger';
-        }
-      }
+      await loadPy();
+      pyStatus.textContent = 'Local compute ready';
+      pyStatus.className = 'ms-auto small text-success';
       try {
         const res = await fetch('./assets/template.csv');
         if (!res.ok) throw new Error(`template load ${res.status}`);
@@ -279,14 +245,13 @@
       previewTitle.style.display = 'none';
       document.getElementById('charts').innerHTML = '';
       clearBtn.style.display = 'none';
-      loading.style.display = 'block';
-      console.log('Processing file', file.name);
+      loading.style.display = 'none';
+      console.log('Loaded file', file.name);
       if (!file.name.toLowerCase().endsWith('.csv')) {
         resultBox.innerHTML = "<div class='error'>Only CSV files are supported.</div>";
-        loading.style.display = 'none';
         return;
       }
-      // Show preview
+      currentFile = file;
       const text = await file.text();
       const rows = text.trim().split('\n').map(r => r.split(','));
       const headers = rows[0];
@@ -296,17 +261,17 @@
       previewTable.innerHTML = html;
       previewTitle.style.display = 'block';
       clearBtn.style.display = 'inline-block';
-      console.log('Loaded file', file.name);
+      scoreBtn.disabled = false;
+    }
 
+    async function computeFile(file) {
+      loading.style.display = 'block';
+      const text = await file.text();
       const selected = Array.from(document.querySelectorAll('.controls input:checked')).map(cb => cb.value);
-      const params = new URLSearchParams();
-      selected.forEach(i => params.append('indices', i));
-
       try {
-        if (isGH && !apiBaseInput.value) {
-          const py = await loadPy();
-          const csvStr = JSON.stringify(text);
-          const pyRes = await py.runPythonAsync(`
+        const py = await loadPy();
+        const csvStr = JSON.stringify(text);
+        const pyRes = await py.runPythonAsync(`
 import pandas as pd, io, json
 from compute.dii import calculate_dii
 from compute.mind import calculate_mind
@@ -332,87 +297,33 @@ if 'DASH' in indices:
 out = {'csv': df.to_csv(index=False), 'stats': stats}
 json.dumps(out)
 `);
-          const info = JSON.parse(pyRes);
-          const csvText = info.csv;
-          const data = csvText.trim().split('\n').map(r => r.split(','));
-          const idx = data[0].reduce((m,h,i) => (m[h]=i,m), {});
-          let summary = '<h3>Summary Statistics:</h3><ul>';
-          selected.forEach(name => {
-            const vals = data.slice(1).map(r => parseFloat(r[idx[name]])).filter(v => !isNaN(v));
-            const s = info.stats[name];
-            summary += `<li><b>${name}</b> – mean: ${parseFloat(s.mean).toFixed(2)}, std: ${parseFloat(s.std).toFixed(2)}, min: ${parseFloat(s.min).toFixed(2)}, max: ${parseFloat(s.max).toFixed(2)}, median: ${parseFloat(s.median).toFixed(2)}, quintiles: ${s.quintiles.map(q=>parseFloat(q).toFixed(2)).join(', ')}</li>`;
-            const chartDiv = document.createElement('div');
-            document.getElementById('charts').append(chartDiv);
-            Plotly.newPlot(chartDiv,[{x:vals,type:'histogram',name}],{title:`${name} Distribution`,margin:{t:40}}, {responsive:true});
-          });
-          summary += '</ul>';
-          resultBox.innerHTML = summary;
-          const blob = new Blob([csvText], {type:'text/csv'});
-          const url = URL.createObjectURL(blob);
-          const a = document.createElement('a');
-          a.href = url;
-          a.download = file.name.replace(/\.csv$/, '') + '_scores.csv';
-          a.click();
-          URL.revokeObjectURL(url);
-          console.log('Scoring complete via Pyodide');
-        } else {
-          const fd = new FormData();
-          fd.append('file', file);
-          const res = await fetch(apiUrl(`/score?${params}`), {
-            method: 'POST',
-            body: fd,
-          });
-          if (!res.ok) {
-            let detail = '';
-            try { detail = (await res.json()).detail; } catch {}
-
-          if (!detail) {
-            const text = await res.text().catch(() => '');
-            detail = text.trim();
-          }
-          if (res.status === 404) {
-            detail = detail || 'Endpoint not found';
-          } else if (res.status === 405) {
-            detail = detail || 'Method not allowed';
-          }
-          const statusLine = `HTTP ${res.status} ${res.statusText}`;
-          throw new Error(detail ? `${statusLine} - ${detail}` : statusLine);
-        }
-          const info = await res.json();
-          const dl = await fetch(apiUrl(`/download/${info.filename}`));
-          if (!dl.ok) {
-            throw new Error(`Download error ${dl.status} ${dl.statusText}`);
-          }
-          const blob = await dl.blob();
-          const csvText = await blob.text();
-          const data = csvText.trim().split('\n').map(r => r.split(','));
-          const idx = data[0].reduce((m,h,i) => (m[h]=i,m), {});
-          let summary = '<h3>Summary Statistics:</h3><ul>';
-          selected.forEach(name => {
-            const vals = data.slice(1).map(r => parseFloat(r[idx[name]])).filter(v => !isNaN(v));
-            const s = computeStats(vals);
-            summary += `<li><b>${name}</b> – mean: ${s.mean}, std: ${s.std}, min: ${s.min}, max: ${s.max}, median: ${s.median}, quintiles: ${s.quintiles.join(', ')}</li>`;
-            const chartDiv = document.createElement('div');
-            document.getElementById('charts').append(chartDiv);
-            Plotly.newPlot(chartDiv,[{x:vals,type:'histogram',name}],{title:`${name} Distribution`,margin:{t:40}}, {responsive:true});
-          });
-          summary += '</ul>';
-          resultBox.innerHTML = summary;
-          const url = URL.createObjectURL(blob);
-          const a = document.createElement('a');
-          a.href = url;
-          a.download = file.name.replace(/\.csv$/, '') + '_scores.csv';
-          a.click();
-          URL.revokeObjectURL(url);
-          console.log('Scoring complete, results downloaded');
-        }
+        const info = JSON.parse(pyRes);
+        const csvText = info.csv;
+        const data = csvText.trim().split('\n').map(r => r.split(','));
+        const idx = data[0].reduce((m,h,i) => (m[h]=i,m), {});
+        let summary = '<h3>Summary Statistics:</h3><ul>';
+        selected.forEach(name => {
+          const vals = data.slice(1).map(r => parseFloat(r[idx[name]])).filter(v => !isNaN(v));
+          const s = info.stats[name];
+          summary += `<li><b>${name}</b> – mean: ${parseFloat(s.mean).toFixed(2)}, std: ${parseFloat(s.std).toFixed(2)}, min: ${parseFloat(s.min).toFixed(2)}, max: ${parseFloat(s.max).toFixed(2)}, median: ${parseFloat(s.median).toFixed(2)}, quintiles: ${s.quintiles.map(q=>parseFloat(q).toFixed(2)).join(', ')}</li>`;
+          const chartDiv = document.createElement('div');
+          document.getElementById('charts').append(chartDiv);
+          Plotly.newPlot(chartDiv,[{x:vals,type:'histogram',name}],{title:`${name} Distribution`,margin:{t:40}}, {responsive:true});
+        });
+        summary += '</ul>';
+        resultBox.innerHTML = summary;
+        const blob = new Blob([csvText], {type:'text/csv'});
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = file.name.replace(/\.csv$/, '') + '_scores.csv';
+        a.click();
+        URL.revokeObjectURL(url);
+        console.log('Scoring complete via Pyodide');
       } catch(err) {
         console.error('Scoring failed', err);
         let msg = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
-        if (msg.includes('Failed to fetch')) {
-          msg = `Failed to reach ${apiUrl('/score')} – the server may be down or CORS blocked.`;
-        }
-        resultBox.innerHTML = `<div class='error'><b>${msg}</b><br><small>Endpoint: ${apiUrl('/score')}<br>API base: ${apiBaseInput.value || 'http://localhost:8000'}</small></div>`;
+        resultBox.innerHTML = `<div class='error'><b>${msg}</b></div>`;
       } finally {
         loading.style.display = 'none';
       }

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,10 @@
+self.addEventListener('install', e => e.waitUntil(self.skipWaiting()));
+self.addEventListener('activate', e => e.waitUntil(self.clients.claim()));
+
+self.addEventListener('fetch', event => {
+  const url = new URL(event.request.url);
+  if (url.pathname === '/api/time') {
+    const body = JSON.stringify({ time: new Date().toISOString() });
+    event.respondWith(new Response(body, { headers: { 'Content-Type': 'application/json' } }));
+  }
+});


### PR DESCRIPTION
## Summary
- streamline README and docs to just open the static page
- register a service worker and demo `/api/time` endpoint
- load `template.csv` in preview and add a button to score & download

## Testing
- `pre-commit run --files README.md docs/index.md index.html sw.js`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f6ffea0e08333afb160cf169b5921