### PR TITLE
Fix DASH scoring on empty data

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -6,11 +6,12 @@ This file provides guidance and context to the AI Codex agent when contributing 
 ## Project Overview
 DietaryCodex is a browser-first tool for computing multiple diet-quality indices
 (DII, MIND, HEI‑2015, DASH). The GitHub Pages site runs the Python scoring
-modules through **Pyodide**, so users can upload a CSV and get results with no
-server required. The same modules under `compute/` double as a Python library
-for offline or programmatic use. A minimal FastAPI backend exists only for
-automated tests. Pre-commit checks (`black`, `isort`, `flake8`) and pytest
-provide quality assurance.
+modules through **Pyodide**, so users can upload a CSV and get results entirely
+client side. The same modules under `compute/` double as a Python library for
+offline or programmatic use. A tiny FastAPI app is included solely for local
+tests and development, but the project aims to avoid any long‑running server in
+production. Pre-commit checks (`black`, `isort`, `flake8`) and pytest provide
+quality assurance.
 
 ## Directory Structure
 ```

--- a/compute/dash.py
+++ b/compute/dash.py
@@ -47,9 +47,10 @@ def calculate_dash(df: pd.DataFrame) -> pd.Series:
         # Compute cohort quintiles (1-5)
         try:
             ranks[col] = pd.qcut(df[col], 5, labels=False, duplicates="drop") + 1
-        except ValueError:
-            # Fallback to percentile-based ranking
-            ranks[col] = (df[col].rank(pct=True) * 5).clip(1, 5).round().astype(int)
+        except (ValueError, IndexError):
+            # Fallback to percentile-based ranking or empty data handling
+            scores = (df[col].rank(pct=True) * 5).clip(1, 5).round()
+            ranks[col] = scores.fillna(3).astype(int)
 
         # Reverse scoring if needed
         if comp["type"] == "reverse":


### PR DESCRIPTION
## Summary
- clarify serverless approach in AGENT docs
- avoid qcut errors in `calculate_dash`

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f7c82a16c8333901cbed3a0246d54