### PR TITLE
Fix numeric validation in Pyodide workflow

### DIFF
--- a/compute/base.py
+++ b/compute/base.py
@@ -39,6 +39,10 @@ def validate_dataframe(df: pd.DataFrame, required_cols: list) -> bool:
     for col in df.columns:
         if col == "id":
             continue
+        # Coerce to numeric to handle values passed as strings
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+
+        # After coercion, the column should be numeric even if it contains NaN
         if not pd.api.types.is_numeric_dtype(df[col]):
             raise ValueError(f"Column '{col}' must be numeric")
 

--- a/index.html
+++ b/index.html
@@ -205,9 +205,13 @@
         const values = line.split(',');
         const obj = {};
         headers.forEach((h, i) => {
-          const v = values[i] ?? '';
-          const num = Number(v);
-          obj[h] = isNaN(num) || v === '' ? v : num;
+          const v = (values[i] ?? '').trim();
+          if (v === '') {
+            obj[h] = null;
+          } else {
+            const num = Number(v);
+            obj[h] = isNaN(num) ? v : num;
+          }
         });
         return obj;
       });
@@ -251,11 +255,10 @@
       pyStatus.textContent = 'Local compute ready';
       pyStatus.className = 'ms-auto small text-success';
       try {
-        const res = await fetch('./assets/template.json');
+        const res = await fetch('./assets/template.csv');
         if (!res.ok) throw new Error(`template load ${res.status}`);
-        const data = await res.json();
-        const csv = jsonToCsv(data);
-        const file = new File([csv], 'template.csv', { type: 'text/csv' });
+        const text = await res.text();
+        const file = new File([text], 'template.csv', { type: 'text/csv' });
         console.log('Loaded default template');
         handleFile(file);
       } catch (err) {
@@ -292,6 +295,7 @@
     async function computeFile(data, name) {
       loading.style.display = 'block';
       const selected = Array.from(document.querySelectorAll('.controls input:checked')).map(cb => cb.value);
+      console.log('Scoring started', { file: name, indices: selected });
       try {
         const py = await loadPy();
         const jsonData = JSON.stringify(data).replace(/'/g, "\\'");
@@ -323,11 +327,11 @@ json.dumps(out)
 `);
         const info = JSON.parse(pyRes);
         const csvText = info.csv;
-        const data = csvText.trim().split('\n').map(r => r.split(','));
-        const idx = data[0].reduce((m,h,i) => (m[h]=i,m), {});
+        const rows = csvText.trim().split('\n').map(r => r.split(','));
+        const idx = rows[0].reduce((m,h,i) => (m[h]=i,m), {});
         let summary = '<h3>Summary Statistics:</h3><ul>';
         selected.forEach(name => {
-          const vals = data.slice(1).map(r => parseFloat(r[idx[name]])).filter(v => !isNaN(v));
+          const vals = rows.slice(1).map(r => parseFloat(r[idx[name]])).filter(v => !isNaN(v));
           const s = info.stats[name];
           summary += `<li><b>${name}</b> – mean: ${parseFloat(s.mean).toFixed(2)}, std: ${parseFloat(s.std).toFixed(2)}, min: ${parseFloat(s.min).toFixed(2)}, max: ${parseFloat(s.max).toFixed(2)}, median: ${parseFloat(s.median).toFixed(2)}, quintiles: ${s.quintiles.map(q=>parseFloat(q).toFixed(2)).join(', ')}</li>`;
           const chartDiv = document.createElement('div');

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -1,0 +1,17 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+
+
+def test_template_csv_loads():
+    csv_path = Path("assets/template.csv")
+    df = pd.read_csv(csv_path)
+    assert not df.empty
+
+
+def test_template_json_valid():
+    json_path = Path("assets/template.json")
+    text = json_path.read_text()
+    data = json.loads(text.replace("NaN", "null"))
+    assert isinstance(data, list) and len(data) > 0

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,17 @@
+import pandas as pd
+
+from compute.base import validate_dataframe
+from compute.dii import DII_PARAMETER_KEYS
+
+
+def test_validate_coerces_numeric_and_allows_nan():
+    cols = DII_PARAMETER_KEYS[:3]  # pick a few columns
+    data = [
+        {cols[0]: "1.5", cols[1]: "", cols[2]: "2"},
+        {cols[0]: "3", cols[1]: "4", cols[2]: None},
+    ]
+    df = pd.DataFrame(data)
+    # Should not raise despite strings and blanks
+    assert validate_dataframe(df, cols)
+    assert df[cols[0]].dtype.kind in "fiu"
+    assert df[cols[1]].isna().all() or df[cols[1]].dtype.kind in "fiu"


### PR DESCRIPTION
## Summary
- parse CSV blanks as null for proper numeric typing
- coerce columns to numeric in `validate_dataframe`
- add regression test for validation logic
- load built-in template CSV at startup
- add asset loading test

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685f851dda8c83338529f59a8a39b99d