### PR TITLE
Add OKR docs and update agent info

### DIFF
--- a/.codexrc
+++ b/.codexrc
@@ -8,3 +8,6 @@ tests:
   - tests/test_scoring.py
 sample_data:
   - assets/template.csv
+docs:
+  - docs/index.md
+  - docs/okrs.md

--- a/AGENT.md
+++ b/AGENT.md
@@ -67,3 +67,9 @@ When the AI agent runs, reference this file to:
 - Adhere to coding standards and pre-commit configuration
 - Follow the development workflow and commands
 - Verify API endpoint signatures in `compute/api.py`
+
+## Current OKRs
+- Keep scoring fully client side using Pyodide.
+- Ship a default CSV template that loads automatically.
+- Document calculations and validation steps clearly.
+- Enforce code quality via pre-commit and pytest in CI.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ Detailed scoring methods, formulas, and reference citations are in [docs/validat
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on branching, testing, and PRs.
 
+## Roadmap & OKRs
+These lightweight objectives keep development focused while ensuring the tool remains fully client side:
+
+- **Objective 1** – reliable scoring from a default template and drag‑and‑drop uploads across modern browsers.
+- **Objective 2** – clear documentation; methods live in [`validation.md`](validation.md) and [`docs/validation_detailed.md`](docs/validation_detailed.md).
+- **Objective 3** – code quality with pre‑commit and pytest enforced in CI.
+
 ---
 
 **License:** MIT

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ Welcome to the documentation portal for the **Dietary Index Web Calculator**. Th
 - [CSV Template](#csv-template)
 - [Development Workflow](#development-workflow)
 - [Contributing](#contributing)
+- [Roadmap & OKRs](okrs.md)
 - [License](#license)
 
 ---
@@ -122,3 +123,6 @@ See the [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines on reporting issues
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](../LICENSE) file for details.
+
+## Roadmap & OKRs
+See [okrs.md](okrs.md) for the current objectives and key results guiding development.

--- a/docs/okrs.md
+++ b/docs/okrs.md
@@ -1,0 +1,21 @@
+# 📈 Project OKRs
+
+This document outlines the **Objectives and Key Results** guiding ongoing development.
+
+## Objective 1 – Reliable Client‑Side Scoring
+- Keep the application 100% browser‑based using Pyodide.
+- Default CSV template loads automatically so new users can try scoring immediately.
+- Drag‑and‑drop file uploads work on all modern browsers.
+- Maintain full functionality without any network connection once loaded.
+
+## Objective 2 – Solid Validation & Documentation
+- Provide clear instructions in the README and docs.
+- Document calculation methods in `validation.md` and `validation_detailed.md`.
+- Add examples and screenshots as features mature.
+
+## Objective 3 – Code Quality & Automation
+- Use pre‑commit (black, isort, flake8) and pytest on every change.
+- Keep test coverage above 80% on the `compute` modules.
+- Run CI via GitHub Actions to catch regressions.
+
+These OKRs are intentionally lightweight. They should remind contributors and AI agents of the project's direction while leaving room for iterative improvement.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,0 +1,5 @@
+# Validation Summary
+
+This page links to the detailed scientific references and methods used to verify
+each diet-quality index. For the full write-up see
+[../validation.md](../validation.md).


### PR DESCRIPTION
## Summary
- outline project OKRs in docs
- update README with roadmap section
- update AGENT guidance for Codex with OKRs
- link new docs from documentation index and fix validation page
- track docs in `.codexrc`

## Testing
- `pre-commit run --files README.md AGENT.md docs/index.md docs/validation.md docs/okrs.md .codexrc`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f987a7e648333aee95ae369bcf2d0