### PR TITLE
Add multi-language parity docs

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -77,3 +77,12 @@ When the AI agent runs, reference this file to:
 ## UI Standard
 - Keep note of "AGENT_STYLE.md" particularly built for OpenAI Codex
 - This file keeps track and organizes the owner's central OKRs required in styling
+
+## Multi-language Library
+DietaryCodex aims to provide equivalent scoring modules in multiple languages.
+The Python implementation is the source of truth, but R, Julia, JavaScript/TypeScript,
+Go, Rust, Java/Kotlin, C#\F#, C++, Scala, Ruby/Lua, and Haskell/OCaml ports are
+expected. **Whenever the logic or signature of a scoring function changes in one
+language, update all other language implementations to match.** This keeps the
+API consistent so users get identical results no matter which language they run.
+See [docs/multi_language.md](docs/multi_language.md) for coordination details.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ Detailed scoring methods, formulas, and reference citations are in [docs/validat
 
 ---
 
+## Multi-language Library
+
+While the browser UI relies on Python via Pyodide, the scoring routines are being ported to additional languages such as R, Julia, TypeScript, Go, Rust, and more. Every port must expose the same function names and arguments. **When a function changes in one language, update all others to keep results consistent.** See [docs/multi_language.md](docs/multi_language.md) for the current list of supported languages.
+
+---
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on branching, testing, and PRs.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ Welcome to the documentation portal for the **Dietary Index Web Calculator**. Th
 - [Validation & Scoring Standards](#validation--scoring-standards)
 - [CSV Template](#csv-template)
 - [Development Workflow](#development-workflow)
+- [Multi-language Library](multi_language.md)
 - [Contributing](#contributing)
 - [Roadmap & OKRs](okrs.md)
 - [License](#license)
@@ -111,6 +112,17 @@ Download the master template for user uploads: [template.csv](../assets/template
 - **Testing**: `make test`
 - **Optional API**: `make dev`
 - **CI**: GitHub Actions runs on push/PR (`.github/workflows/ci.yml`)
+
+---
+
+## Multi-language Library
+
+The scoring algorithms are being ported to several languages beyond Python. Each
+language module should expose the same functions (`calculate_dii`,
+`calculate_mind`, `calculate_hei_2015`, `calculate_dash`). When one
+implementation changes, every other port must be updated to stay in sync. See
+[multi_language.md](multi_language.md) for the list of supported languages and
+workflow tips.
 
 ---
 

--- a/docs/multi_language.md
+++ b/docs/multi_language.md
@@ -1,0 +1,30 @@
+# 🌐 Multi-language Library Overview
+
+This project intends to ship identical scoring libraries in many languages so contributors can work in their preferred environment. The original code base was written in R and then ported to Python. Future ports will follow the same API.
+
+## Supported Languages
+- **R** (reference)
+- **Python** (source of truth)
+- **Julia**
+- **JavaScript / TypeScript**
+- **Go**
+- **Rust**
+- **Java / Kotlin**
+- **C# / F#**
+- **C++**
+- **Scala**
+- **Ruby / Lua**
+- **Haskell / OCaml**
+
+## Core Functions
+Every language implementation must expose these functions with the same behavior and arguments:
+
+- `calculate_dii`
+- `calculate_mind`
+- `calculate_hei_2015`
+- `calculate_dash`
+- utilities for parameter loading and dataframe validation
+
+When any algorithm or function signature changes, **update all language versions at the same time**. Use the Python modules as the authoritative reference and port changes promptly.
+
+The web app relies on Pyodide running the Python code, so keep the browser UI backward compatible even as new language ports are added.


### PR DESCRIPTION
## Summary
- document multi-language parity requirements
- add dedicated `docs/multi_language.md`
- link from README and docs index
- note parity requirement in AGENT guidelines

## Testing
- `pre-commit run --all-files`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_b_685fc72a93a083339a6dc9b7dafd15ca