### PR TITLE
Expand portal intro and add index docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
               rel="stylesheet" />
         <script src="https://cdn.plot.ly/plotly-2.32.0.min.js"></script>
         <script src="https://cdn.jsdelivr.net/pyodide/v0.25.1/full/pyodide.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
         <script>if ("serviceWorker" in navigator){navigator.serviceWorker.register("sw.js").catch(()=>{});}</script>
         <style>
     :root {
@@ -151,6 +152,23 @@
       font-weight: 600;
     }
     .error { color: var(--accent); font-weight: bold; }
+    .accordion-item {
+      border: 1px solid var(--border);
+      border-radius: 1.5rem;
+      box-shadow: 0 4px 16px rgba(0,45,114,0.05);
+      overflow: hidden;
+      margin-bottom: 1rem;
+    }
+    .accordion-button {
+      font-weight: 600;
+      color: var(--text);
+      background: var(--bg);
+    }
+    .accordion-button:not(.collapsed) {
+      color: var(--primary);
+      background: rgba(25,118,210,0.05);
+    }
+    .accordion-body small { color: var(--text); }
         </style>
     </head>
     <body>
@@ -163,11 +181,18 @@
                       margin-top:2rem">
                 <img src="assets/UF_gen_ai.png" alt="UF Logo" />
             </a>
+            <h1>Dietary Index Portal</h1>
             <p class="lead">
                 The Department of Health Outcomes & Biomedical Informatics
                 (HOBI) at the University of Florida advances research and
                 data science for better care. Tap the logo to explore our
                 programs and open-source tools.
+            </p>
+            <p class="fw-semibold" style="max-width:720px;margin:0 auto;">
+                This portal calculates four evidence-based diet-quality
+                scores—Dietary Inflammatory Index (DII), MIND, Healthy Eating
+                Index 2015 (HEI‑2015), and DASH—directly from your CSV
+                uploads.
             </p>
             <a class="btn btn-primary hero-btn"
                href="https://hobi.med.ufl.edu/"
@@ -213,6 +238,92 @@
             <div id="loading">⏳ Scoring in progress...</div>
             <div id="result"></div>
             <div id="charts"></div>
+            <div class="accordion mt-5" id="indexDocs">
+                <div class="accordion-item">
+                    <h2 class="accordion-header" id="diiHead">
+                        <button class="accordion-button collapsed"
+                                type="button"
+                                data-bs-toggle="collapse"
+                                data-bs-target="#diiBody"
+                                aria-expanded="false"
+                                aria-controls="diiBody">Dietary Inflammatory Index (DII)</button>
+                    </h2>
+                    <div id="diiBody"
+                         class="accordion-collapse collapse"
+                         aria-labelledby="diiHead"
+                         data-bs-parent="#indexDocs">
+                        <div class="accordion-body">
+                            <p>Measures the inflammatory potential of diet using 45 nutrient parameters.</p>
+                            <p>
+                                <small>Hébert JR, Shivappa N, et&nbsp;al. Public Health Nutr. 2014.</small>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="accordion-item">
+                    <h2 class="accordion-header" id="mindHead">
+                        <button class="accordion-button collapsed"
+                                type="button"
+                                data-bs-toggle="collapse"
+                                data-bs-target="#mindBody"
+                                aria-expanded="false"
+                                aria-controls="mindBody">MIND Diet Score</button>
+                    </h2>
+                    <div id="mindBody"
+                         class="accordion-collapse collapse"
+                         aria-labelledby="mindHead"
+                         data-bs-parent="#indexDocs">
+                        <div class="accordion-body">
+                            <p>Assesses adherence to the Mediterranean-DASH Intervention for Neurodegenerative Delay diet.</p>
+                            <p>
+                                <small>Morris MC, Tangney CC, et&nbsp;al. Alzheimers Dement. 2015.</small>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="accordion-item">
+                    <h2 class="accordion-header" id="heiHead">
+                        <button class="accordion-button collapsed"
+                                type="button"
+                                data-bs-toggle="collapse"
+                                data-bs-target="#heiBody"
+                                aria-expanded="false"
+                                aria-controls="heiBody">Healthy Eating Index&nbsp;2015 (HEI‑2015)</button>
+                    </h2>
+                    <div id="heiBody"
+                         class="accordion-collapse collapse"
+                         aria-labelledby="heiHead"
+                         data-bs-parent="#indexDocs">
+                        <div class="accordion-body">
+                            <p>Measures conformance to the 2015&ndash;2020 U.S. Dietary Guidelines across 13 components.</p>
+                            <p>
+                                <small>Krebs-Smith SM, Pannucci TE, et&nbsp;al. J Acad Nutr Diet. 2018.</small>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="accordion-item">
+                    <h2 class="accordion-header" id="dashHead">
+                        <button class="accordion-button collapsed"
+                                type="button"
+                                data-bs-toggle="collapse"
+                                data-bs-target="#dashBody"
+                                aria-expanded="false"
+                                aria-controls="dashBody">DASH Score</button>
+                    </h2>
+                    <div id="dashBody"
+                         class="accordion-collapse collapse"
+                         aria-labelledby="dashHead"
+                         data-bs-parent="#indexDocs">
+                        <div class="accordion-body">
+                            <p>Rates adherence to the Dietary Approaches to Stop Hypertension eating pattern.</p>
+                            <p>
+                                <small>Fung TT, Chiuve SE, et&nbsp;al. JAMA. 2008.</small>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </main>
         <script>
     const dropzone = document.getElementById('dropzone');


### PR DESCRIPTION
## Summary
- clarify that the page is a portal that computes four diet-quality scores
- include short explanation near the header
- document each score with references in an accordion
- load Bootstrap JS to power the accordion

## Testing
- `pre-commit run --files index.html`
- `pytest -q` *(fails: ModuleNotFoundError: pandas)*

------
https://chatgpt.com/codex/tasks/task_b_685fcdaefa1c8333808995d74fbe4c08