### PR TITLE
Add MEDI diet scoring

### DIFF
--- a/compute/__init__.py
+++ b/compute/__init__.py
@@ -1,10 +1,10 @@
 __version__ = "0.1.0"
 
 from .ahei import AHEI_COMPONENT_KEYS, calculate_ahei  # noqa: F401
-
 from .hei import (  # noqa: F401
     HEI_COMPONENT_KEYS,
     calculate_hei_2015,
     calculate_hei_2020,
     calculate_hei_toddlers_2020,
 )
+from .medi import MEDI_COMPONENT_KEYS, calculate_medi  # noqa: F401

--- a/compute/api.py
+++ b/compute/api.py
@@ -20,6 +20,7 @@ from compute.hei import (
     calculate_hei_2020,
     calculate_hei_toddlers_2020,
 )
+from compute.medi import MEDI_COMPONENT_KEYS, calculate_medi
 from compute.mind import MIND_COMPONENT_KEYS, calculate_mind
 
 logging.basicConfig(level=logging.INFO)
@@ -44,6 +45,7 @@ REQUIRED_COLS = (
     + MIND_COMPONENT_KEYS
     + DASH_COMPONENT_KEYS
     + AHEI_COMPONENT_KEYS
+    + MEDI_COMPONENT_KEYS
 )
 
 app = FastAPI(
@@ -128,6 +130,9 @@ async def score_diet_indices(
     if "AHEI" in indices:
         logger.info("Computing AHEI...")
         results["AHEI"] = calculate_ahei(df)
+    if "MEDI" in indices:
+        logger.info("Computing MEDI...")
+        results["MEDI"] = calculate_medi(df)
 
     # Attach results to DataFrame
     for name, series in results.items():

--- a/compute/medi.py
+++ b/compute/medi.py
@@ -1,0 +1,38 @@
+import pandas as pd
+
+from compute.base import validate_dataframe
+
+# Component definitions for MEDI (PREDIMED serving sizes)
+# Each component contributes 0 or 1 point based on a cutoff
+_MEDI_COMPONENTS = [
+    {"key": "olive_oil_serv_medi", "op": ">=", "threshold": 5},
+    {"key": "frt_serv_medi", "op": ">=", "threshold": 3},
+    {"key": "veg_serv_medi", "op": ">=", "threshold": 2},
+    {"key": "legumes_serv_medi", "op": ">=", "threshold": 3 / 7},
+    {"key": "nuts_serv_medi", "op": ">=", "threshold": 3 / 7},
+    {"key": "fish_seafood_serv_medi", "op": ">=", "threshold": 3 / 7},
+    {"key": "alcohol_serv_medi", "op": ">=", "threshold": 1},
+    {"key": "ssb_serv_medi", "op": "<", "threshold": 1},
+    {"key": "sweets_serv_medi", "op": "<", "threshold": 2 / 7},
+    {"key": "discret_fat_serv_medi", "op": "<", "threshold": 1},
+    {"key": "redproc_meat_serv_medi", "op": "<", "threshold": 1},
+]
+
+# Expose component keys for validation
+MEDI_COMPONENT_KEYS = [c["key"] for c in _MEDI_COMPONENTS]
+
+
+def calculate_medi(df: pd.DataFrame) -> pd.Series:
+    """Calculate Mediterranean Diet Index (MEDI) from serving sizes."""
+    validate_dataframe(df, MEDI_COMPONENT_KEYS)
+
+    score = pd.Series(0, index=df.index, dtype=float)
+    for comp in _MEDI_COMPONENTS:
+        col = comp["key"]
+        thresh = comp["threshold"]
+        if comp["op"] == ">=":
+            score += (df[col] >= thresh).astype(int)
+        else:
+            score += (df[col] < thresh).astype(int)
+
+    return score

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ Welcome to the documentation portal for the **Dietary Index Web Calculator**. Th
 ## Overview
 
 The **Dietary Index Web Calculator** lets users compute multiple diet-quality
-indices (DII, MIND, HEI‑2015, DASH) right in the browser. The GitHub Pages site
+indices (DII, MIND, HEI‑2015, HEI‑2020, HEI‑Toddlers‑2020, AHEI, DASH, MEDI) right in the browser. The GitHub Pages site
  runs the Python scoring modules via **Pyodide**, so no server is required. A
  minimal FastAPI backend exists only for automated tests.
 
@@ -49,6 +49,8 @@ Open the hosted site or `index.html` locally. A service worker provides a demo `
 │   ├── hei.py              # Healthy Eating Index 2015
 │   ├── mind.py             # MIND diet score
 │   ├── dash.py             # DASH diet score
+│   ├── ahei.py             # Alternative Healthy Eating Index
+│   ├── medi.py             # Mediterranean Diet Index
 │   └── dii_parameters.json # DII global parameters
 ├── docs/                   # Documentation files
 │   ├── index.md            # This file
@@ -80,7 +82,8 @@ Open the hosted site or `index.html` locally. A service worker provides a demo `
 ### Score Endpoint
 
 - **Endpoint**: `POST /score`
-- **Description**: Upload a CSV and optionally specify `?indices=DII,MIND,HEI_2015,DASH`.
+- **Description**: Upload a CSV and optionally specify
+  `?indices=DII,MIND,HEI_2015,HEI_2020,HEI_TODDLERS_2020,DASH,AHEI,MEDI`.
 - **Response**: JSON with `filename` and `stats` (mean, std, min, max, median, quintiles).
 
 ### Download Endpoint

--- a/docs/validation_detailed.md
+++ b/docs/validation_detailed.md
@@ -43,8 +43,16 @@ It is intended as a reference for researchers and future contributors who requir
 - **Scoring**: Linear scaling to 10 points per component with gender-specific cut points for whole grains and alcohol. Sodium is scored on cohort-specific deciles.
 - **Range**: 0–110 when all components are summed.
 - **Validation**: The Python port mirrors the published R implementation from the `dietaryindex` package. Synthetic inputs cover gender and sodium decile edge cases.
+## 6. MED Index in Serving Sizes (MEDI)
 
-## 6. Healthy Eating Index 2020
+- **Components**: Olive oil, fruit, vegetables, legumes, nuts, fish/seafood, alcohol,
+  sugar-sweetened beverages, sweets, discretionary fats, and red/processed meat.
+- **Scoring**: Each component earns 1 point when the PREDIMED threshold is met; otherwise 0.
+- **Range**: 0–11 (10 if alcohol is excluded).
+- **Validation**: Ported directly from the R `dietaryindex` package.
+
+
+## 7. Healthy Eating Index 2020
 
 - **Components**: 13 dietary elements similar to HEI‑2015 but with updated cut points.
 - **Variants**: Standard HEI‑2020 for adults and HEI‑Toddlers‑2020 for children aged 1–2 years.

--- a/openapi.yml
+++ b/openapi.yml
@@ -28,7 +28,7 @@ paths:
           in: query
           description: |
             Optional comma-separated list of indices to compute.
-            Valid values: DII, MIND, HEI_2015, DASH.
+            Valid values: DII, MIND, HEI_2015, HEI_2020, HEI_TODDLERS_2020, DASH, AHEI, MEDI.
           required: false
           schema:
             type: array

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -11,6 +11,7 @@ from compute.hei import (
     calculate_hei_2020,
     calculate_hei_toddlers_2020,
 )
+from compute.medi import MEDI_COMPONENT_KEYS, calculate_medi
 from compute.mind import MIND_COMPONENT_KEYS, calculate_mind
 
 
@@ -82,3 +83,11 @@ def test_ahei_output_length():
     result = calculate_ahei(df)
     assert isinstance(result, pd.Series)
     assert len(result) == 6
+
+
+def test_medi_output_length():
+    cols = MEDI_COMPONENT_KEYS
+    df = make_dummy_df(cols, n=4)
+    result = calculate_medi(df)
+    assert isinstance(result, pd.Series)
+    assert len(result) == 4


### PR DESCRIPTION
## Summary
- implement MEDI index scoring logic and export it
- expose MEDI via API and docs
- include MEDI in OpenAPI spec and project docs
- add MEDI unit test

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6860a5d871108333bef6f9f175195e41