### PR TITLE
Add Planetary Health Diet Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dietary Index Web Calculator
 
-**A browser-based tool for computing multiple diet-quality scores (DII, MIND, HEI‑2015, HEI‑2020, HEI‑Toddlers‑2020, DASH, AHEI) from nutrition CSV data**. The GitHub Pages site uses Pyodide so it works without any backend server.
+**A browser-based tool for computing multiple diet-quality scores (DII, MIND, HEI‑2015, HEI‑2020, HEI‑Toddlers‑2020, DASH, AHEI, MEDI, PHDI) from nutrition CSV data**. The GitHub Pages site uses Pyodide so it works without any backend server.
 
 This repository doubles as a high-quality corpus for exploring generative AI techniques in nutrition science. By openly documenting every algorithm and validation step, we hope future models can learn from these methods and foster collaborative research across disciplines.
 

--- a/compute/__init__.py
+++ b/compute/__init__.py
@@ -8,3 +8,4 @@ from .hei import (  # noqa: F401
     calculate_hei_toddlers_2020,
 )
 from .medi import MEDI_COMPONENT_KEYS, calculate_medi  # noqa: F401
+from .phdi import PHDI_COMPONENT_KEYS, calculate_phdi  # noqa: F401

--- a/compute/api.py
+++ b/compute/api.py
@@ -22,6 +22,7 @@ from compute.hei import (
 )
 from compute.medi import MEDI_COMPONENT_KEYS, calculate_medi
 from compute.mind import MIND_COMPONENT_KEYS, calculate_mind
+from compute.phdi import PHDI_COMPONENT_KEYS, calculate_phdi
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -46,6 +47,7 @@ REQUIRED_COLS = (
     + DASH_COMPONENT_KEYS
     + AHEI_COMPONENT_KEYS
     + MEDI_COMPONENT_KEYS
+    + PHDI_COMPONENT_KEYS
 )
 
 app = FastAPI(
@@ -133,6 +135,9 @@ async def score_diet_indices(
     if "MEDI" in indices:
         logger.info("Computing MEDI...")
         results["MEDI"] = calculate_medi(df)
+    if "PHDI" in indices:
+        logger.info("Computing PHDI...")
+        results["PHDI"] = calculate_phdi(df)
 
     # Attach results to DataFrame
     for name, series in results.items():

--- a/compute/phdi.py
+++ b/compute/phdi.py
@@ -1,0 +1,82 @@
+import numpy as np
+import pandas as pd
+
+from compute.base import validate_dataframe
+
+# Component thresholds for Planetary Health Diet Index (PHDI)
+# Values in grams/day unless noted otherwise
+_PHDI_COMPONENTS = [
+    {"key": "wgrain_serv_phdi", "type": "wgrain"},
+    {"key": "starchy_veg_serv_phdi", "type": "unhealthy", "min": 200.0, "max": 50.0},
+    {"key": "veg_serv_phdi", "type": "healthy", "min": 0.0, "max": 300.0},
+    {"key": "frt_serv_phdi", "type": "healthy", "min": 0.0, "max": 200.0},
+    {"key": "dairy_serv_phdi", "type": "unhealthy", "min": 1000.0, "max": 250.0},
+    {"key": "redproc_meat_serv_phdi", "type": "unhealthy", "min": 100.0, "max": 14.0},
+    {"key": "poultry_serv_phdi", "type": "unhealthy", "min": 100.0, "max": 29.0},
+    {"key": "egg_serv_phdi", "type": "unhealthy", "min": 120.0, "max": 13.0},
+    {"key": "fish_serv_phdi", "type": "healthy", "min": 0.0, "max": 28.0},
+    {"key": "nuts_serv_phdi", "type": "healthy", "min": 0.0, "max": 50.0},
+    {"key": "legumes_serv_phdi", "type": "healthy5", "min": 0.0, "max": 100.0},
+    {"key": "soy_serv_phdi", "type": "healthy5", "min": 0.0, "max": 50.0},
+    {"key": "added_fat_unsat_serv_phdi", "type": "healthy", "min": 3.5, "max": 21.0},
+    {
+        "key": "added_fat_sat_trans_serv_phdi",
+        "type": "unhealthy",
+        "min": 10.0,
+        "max": 0.0,
+    },
+    {"key": "added_sugar_serv_phdi", "type": "unhealthy", "min": 25.0, "max": 5.0},
+]
+
+# Expose for validation
+PHDI_COMPONENT_KEYS = [c["key"] for c in _PHDI_COMPONENTS] + ["gender"]
+
+
+def _score_healthy(
+    series: pd.Series, min_val: float, max_val: float, max_score: float
+) -> pd.Series:
+    score = (series - min_val) * max_score / (max_val - min_val)
+    score[series >= max_val] = max_score
+    score[series <= min_val] = 0.0
+    return score.clip(0.0, max_score)
+
+
+def _score_unhealthy(
+    series: pd.Series, min_val: float, max_val: float, max_score: float
+) -> pd.Series:
+    score = (series - min_val) * max_score / (max_val - min_val)
+    score[series >= min_val] = 0.0
+    score[series <= max_val] = max_score
+    return score.clip(0.0, max_score)
+
+
+def calculate_phdi(df: pd.DataFrame) -> pd.Series:
+    """Calculate Planetary Health Diet Index (PHDI)."""
+    validate_dataframe(df, PHDI_COMPONENT_KEYS)
+
+    gender = df["gender"]
+    scores = pd.DataFrame(index=df.index)
+
+    for comp in _PHDI_COMPONENTS:
+        key = comp["key"]
+        max_score = 10.0
+        if comp["type"] == "wgrain":
+            max_vals = np.where(gender == 2, 75.0, 90.0)
+            score = (df[key] - 0.0) * max_score / (max_vals - 0.0)
+            score[df[key] >= max_vals] = max_score
+            score[df[key] <= 0.0] = 0.0
+            scores[key] = pd.Series(score, index=df.index).clip(0.0, max_score)
+        else:
+            if comp["type"] == "healthy":
+                scores[key] = _score_healthy(
+                    df[key], comp["min"], comp["max"], max_score
+                )
+            elif comp["type"] == "healthy5":
+                scores[key] = _score_healthy(df[key], comp["min"], comp["max"], 5.0)
+            else:
+                scores[key] = _score_unhealthy(
+                    df[key], comp["min"], comp["max"], max_score
+                )
+
+    total = scores.sum(axis=1)
+    return total

--- a/docs/validation_detailed.md
+++ b/docs/validation_detailed.md
@@ -59,6 +59,13 @@ It is intended as a reference for researchers and future contributors who requir
 - **Range**: 0–100.
 - **Validation**: Thresholds and scoring logic are ported from the R `dietaryindex` package.
 
+## 8. Planetary Health Diet Index (PHDI)
+
+- **Origin**: Proposed by the EAT‑Lancet Commission for sustainable diets.
+- **Scoring**: Components scaled from 0–10 (legumes and soy max 5) with gender‑specific cut points for whole grains.
+- **Range**: 0–140 when summed across all components.
+- **Validation**: Implemented according to the R `dietaryindex` package which serves as the reference implementation.
+
 ---
 
 ## Cross‑validation Workflow

--- a/openapi.yml
+++ b/openapi.yml
@@ -28,7 +28,7 @@ paths:
           in: query
           description: |
             Optional comma-separated list of indices to compute.
-            Valid values: DII, MIND, HEI_2015, HEI_2020, HEI_TODDLERS_2020, DASH, AHEI, MEDI.
+            Valid values: DII, MIND, HEI_2015, HEI_2020, HEI_TODDLERS_2020, DASH, AHEI, MEDI, PHDI.
           required: false
           schema:
             type: array

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -13,6 +13,7 @@ from compute.hei import (
 )
 from compute.medi import MEDI_COMPONENT_KEYS, calculate_medi
 from compute.mind import MIND_COMPONENT_KEYS, calculate_mind
+from compute.phdi import PHDI_COMPONENT_KEYS, calculate_phdi
 
 
 def make_dummy_df(cols, n=10, fill_value=1.0):
@@ -91,3 +92,12 @@ def test_medi_output_length():
     result = calculate_medi(df)
     assert isinstance(result, pd.Series)
     assert len(result) == 4
+
+
+def test_phdi_output_length():
+    cols = PHDI_COMPONENT_KEYS
+    df = make_dummy_df(cols, n=3)
+    df["gender"] = 1
+    result = calculate_phdi(df)
+    assert isinstance(result, pd.Series)
+    assert len(result) == 3


### PR DESCRIPTION
## Summary
- port PHDI algorithm from the dietaryindex R package
- expose `calculate_phdi` in compute package and API
- document PHDI in validation guide and README
- allow `PHDI` option in API and test the new scorer

## Testing
- `pre-commit run --all-files`
- `pytest -v`


------
https://chatgpt.com/codex/tasks/task_b_6860a920add88333a167580139e7f1c2