### PR TITLE
Expand scoring with AHEIP support

### DIFF
--- a/compute/__init__.py
+++ b/compute/__init__.py
@@ -7,6 +7,7 @@ from .acs2020 import (  # noqa: F401
     calculate_acs2020_v2,
 )
 from .ahei import AHEI_COMPONENT_KEYS, calculate_ahei  # noqa: F401
+from .aheip import AHEIP_COMPONENT_KEYS, calculate_aheip  # noqa: F401
 from .hei import (  # noqa: F401
     HEI_COMPONENT_KEYS,
     calculate_hei_2015,

--- a/compute/__init__.py
+++ b/compute/__init__.py
@@ -14,5 +14,10 @@ from .hei import (  # noqa: F401
     calculate_hei_2020,
     calculate_hei_toddlers_2020,
 )
-from .medi import MEDI_COMPONENT_KEYS, calculate_medi  # noqa: F401
+from .medi import (  # noqa: F401
+    MEDI_COMPONENT_KEYS,
+    MEDI_V2_COMPONENT_KEYS,
+    calculate_medi,
+    calculate_medi_v2,
+)
 from .phdi import PHDI_COMPONENT_KEYS, calculate_phdi  # noqa: F401

--- a/compute/aheip.py
+++ b/compute/aheip.py
@@ -1,0 +1,46 @@
+import pandas as pd
+
+from compute.base import validate_dataframe
+
+_AHEIP_COMPONENTS = [
+    {"key": "VEG_SERV_AHEIP", "type": "healthy", "min": 0.0, "max": 5.0},
+    {"key": "FRT_SERV_AHEIP", "type": "healthy", "min": 0.0, "max": 4.0},
+    {"key": "WHITERED_RT_SERV_AHEIP", "type": "healthy", "min": 0.0, "max": 4.0},
+    {"key": "FIBER_SERV_AHEIP", "type": "healthy", "min": 0.0, "max": 25.0},
+    {"key": "TRANS_SERV_AHEIP", "type": "unhealthy", "min": 4.0, "max": 0.5},
+    {"key": "POLYSAT_RT_SERV_AHEIP", "type": "healthy", "min": 0.1, "max": 1.0},
+    {"key": "CALCIUM_SERV_AHEIP", "type": "healthy", "min": 0.0, "max": 1200.0},
+    {"key": "FOLATE_SERV_AHEIP", "type": "healthy", "min": 0.0, "max": 600.0},
+    {"key": "IRON_SERV_AHEIP", "type": "healthy", "min": 0.0, "max": 27.0},
+]
+
+AHEIP_COMPONENT_KEYS = [c["key"] for c in _AHEIP_COMPONENTS]
+
+
+def _score_healthy(series: pd.Series, min_val: float, max_val: float) -> pd.Series:
+    score = (series - min_val) * 10 / (max_val - min_val)
+    score[series >= max_val] = 10.0
+    score[series <= min_val] = 0.0
+    return score.clip(0.0, 10.0)
+
+
+def _score_unhealthy(series: pd.Series, min_val: float, max_val: float) -> pd.Series:
+    score = (series - min_val) * 10 / (max_val - min_val)
+    score[series >= min_val] = 0.0
+    score[series <= max_val] = 10.0
+    return score.clip(0.0, 10.0)
+
+
+def calculate_aheip(df: pd.DataFrame) -> pd.Series:
+    """Calculate serving-based Alternative Healthy Eating Index (AHEIP)."""
+    validate_dataframe(df, AHEIP_COMPONENT_KEYS)
+
+    scores = pd.DataFrame(index=df.index)
+    for comp in _AHEIP_COMPONENTS:
+        key = comp["key"]
+        if comp["type"] == "healthy":
+            scores[key] = _score_healthy(df[key], comp["min"], comp["max"])
+        else:
+            scores[key] = _score_unhealthy(df[key], comp["min"], comp["max"])
+
+    return scores.sum(axis=1)

--- a/compute/api.py
+++ b/compute/api.py
@@ -18,6 +18,7 @@ from compute.acs2020 import (
     calculate_acs2020_v2,
 )
 from compute.ahei import AHEI_COMPONENT_KEYS, calculate_ahei
+from compute.aheip import AHEIP_COMPONENT_KEYS, calculate_aheip
 from compute.dash import DASH_COMPONENT_KEYS, calculate_dash
 from compute.dii import calculate_dii, get_dii_parameters
 from compute.hei import (
@@ -52,6 +53,7 @@ REQUIRED_COLS = (
     + MIND_COMPONENT_KEYS
     + DASH_COMPONENT_KEYS
     + AHEI_COMPONENT_KEYS
+    + AHEIP_COMPONENT_KEYS
     + MEDI_COMPONENT_KEYS
     + PHDI_COMPONENT_KEYS
     + ACS2020_V1_KEYS
@@ -140,6 +142,9 @@ async def score_diet_indices(
     if "AHEI" in indices:
         logger.info("Computing AHEI...")
         results["AHEI"] = calculate_ahei(df)
+    if "AHEIP" in indices:
+        logger.info("Computing AHEIP...")
+        results["AHEIP"] = calculate_aheip(df)
     if "MEDI" in indices:
         logger.info("Computing MEDI...")
         results["MEDI"] = calculate_medi(df)

--- a/compute/api.py
+++ b/compute/api.py
@@ -27,7 +27,12 @@ from compute.hei import (
     calculate_hei_2020,
     calculate_hei_toddlers_2020,
 )
-from compute.medi import MEDI_COMPONENT_KEYS, calculate_medi
+from compute.medi import (
+    MEDI_COMPONENT_KEYS,
+    MEDI_V2_COMPONENT_KEYS,
+    calculate_medi,
+    calculate_medi_v2,
+)
 from compute.mind import MIND_COMPONENT_KEYS, calculate_mind
 from compute.phdi import PHDI_COMPONENT_KEYS, calculate_phdi
 
@@ -55,6 +60,7 @@ REQUIRED_COLS = (
     + AHEI_COMPONENT_KEYS
     + AHEIP_COMPONENT_KEYS
     + MEDI_COMPONENT_KEYS
+    + MEDI_V2_COMPONENT_KEYS
     + PHDI_COMPONENT_KEYS
     + ACS2020_V1_KEYS
     + ACS2020_V2_KEYS
@@ -148,6 +154,9 @@ async def score_diet_indices(
     if "MEDI" in indices:
         logger.info("Computing MEDI...")
         results["MEDI"] = calculate_medi(df)
+    if "MEDI_V2" in indices:
+        logger.info("Computing MEDI_V2...")
+        results["MEDI_V2"] = calculate_medi_v2(df)
     if "PHDI" in indices:
         logger.info("Computing PHDI...")
         results["PHDI"] = calculate_phdi(df)

--- a/compute/medi.py
+++ b/compute/medi.py
@@ -21,6 +21,28 @@ _MEDI_COMPONENTS = [
 # Expose component keys for validation
 MEDI_COMPONENT_KEYS = [c["key"] for c in _MEDI_COMPONENTS]
 
+# Component definitions for MEDI_V2 (serving-based 0-5 scoring)
+_MEDI_V2_COMPONENTS = [
+    {"key": "olive_oil_serv_medi", "type": "healthy", "min": 0.0, "max": 5.0},
+    {"key": "frt_serv_medi", "type": "healthy", "min": 0.0, "max": 3.0},
+    {"key": "veg_serv_medi", "type": "healthy", "min": 0.0, "max": 2.0},
+    {"key": "legumes_serv_medi", "type": "healthy", "min": 0.0, "max": 3 / 7},
+    {"key": "nuts_serv_medi", "type": "healthy", "min": 0.0, "max": 3 / 7},
+    {
+        "key": "fish_seafood_serv_medi",
+        "type": "healthy",
+        "min": 0.0,
+        "max": 3 / 7,
+    },
+    {"key": "alcohol_serv_medi", "type": "healthy", "min": 0.0, "max": 1.0},
+    {"key": "ssb_serv_medi", "type": "unhealthy", "min": 1.0, "max": 0.0},
+    {"key": "sweets_serv_medi", "type": "unhealthy", "min": 2 / 7, "max": 0.0},
+    {"key": "discret_fat_serv_medi", "type": "unhealthy", "min": 1.0, "max": 0.0},
+    {"key": "redproc_meat_serv_medi", "type": "unhealthy", "min": 1.0, "max": 0.0},
+]
+
+MEDI_V2_COMPONENT_KEYS = [c["key"] for c in _MEDI_V2_COMPONENTS]
+
 
 def calculate_medi(df: pd.DataFrame) -> pd.Series:
     """Calculate Mediterranean Diet Index (MEDI) from serving sizes."""
@@ -36,3 +58,35 @@ def calculate_medi(df: pd.DataFrame) -> pd.Series:
             score += (df[col] < thresh).astype(int)
 
     return score
+
+
+def _score_healthy(series: pd.Series, min_val: float, max_val: float) -> pd.Series:
+    score = (series - min_val) * 5 / (max_val - min_val)
+    score[series >= max_val] = 5.0
+    score[series <= min_val] = 0.0
+    return score.clip(0.0, 5.0)
+
+
+def _score_unhealthy(series: pd.Series, min_val: float, max_val: float) -> pd.Series:
+    score = (series - min_val) * 5 / (max_val - min_val)
+    score[series >= min_val] = 0.0
+    score[series <= max_val] = 5.0
+    return score.clip(0.0, 5.0)
+
+
+def calculate_medi_v2(df: pd.DataFrame) -> pd.Series:
+    """Calculate Mediterranean Diet Index version 2 (0–5 per component)."""
+    validate_dataframe(df, MEDI_V2_COMPONENT_KEYS)
+
+    scores = pd.DataFrame(index=df.index)
+    for comp in _MEDI_V2_COMPONENTS:
+        if comp["type"] == "healthy":
+            scores[comp["key"]] = _score_healthy(
+                df[comp["key"]], comp["min"], comp["max"]
+            )
+        else:
+            scores[comp["key"]] = _score_unhealthy(
+                df[comp["key"]], comp["min"], comp["max"]
+            )
+
+    return scores.sum(axis=1)

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -18,7 +18,12 @@ from compute.hei import (
     calculate_hei_2020,
     calculate_hei_toddlers_2020,
 )
-from compute.medi import MEDI_COMPONENT_KEYS, calculate_medi
+from compute.medi import (
+    MEDI_COMPONENT_KEYS,
+    MEDI_V2_COMPONENT_KEYS,
+    calculate_medi,
+    calculate_medi_v2,
+)
 from compute.mind import MIND_COMPONENT_KEYS, calculate_mind
 from compute.phdi import PHDI_COMPONENT_KEYS, calculate_phdi
 
@@ -105,6 +110,14 @@ def test_medi_output_length():
     cols = MEDI_COMPONENT_KEYS
     df = make_dummy_df(cols, n=4)
     result = calculate_medi(df)
+    assert isinstance(result, pd.Series)
+    assert len(result) == 4
+
+
+def test_medi_v2_output_length():
+    cols = MEDI_V2_COMPONENT_KEYS
+    df = make_dummy_df(cols, n=4)
+    result = calculate_medi_v2(df)
     assert isinstance(result, pd.Series)
     assert len(result) == 4
 

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -9,6 +9,7 @@ from compute.acs2020 import (
     calculate_acs2020_v2,
 )
 from compute.ahei import AHEI_COMPONENT_KEYS, calculate_ahei
+from compute.aheip import AHEIP_COMPONENT_KEYS, calculate_aheip
 from compute.dash import DASH_COMPONENT_KEYS, calculate_dash
 from compute.dii import calculate_dii, get_dii_parameters
 from compute.hei import (
@@ -90,6 +91,14 @@ def test_ahei_output_length():
     result = calculate_ahei(df)
     assert isinstance(result, pd.Series)
     assert len(result) == 6
+
+
+def test_aheip_output_length():
+    cols = AHEIP_COMPONENT_KEYS
+    df = make_dummy_df(cols, n=5)
+    result = calculate_aheip(df)
+    assert isinstance(result, pd.Series)
+    assert len(result) == 5
 
 
 def test_medi_output_length():


### PR DESCRIPTION
## Summary
- implement AHEIP calculation in Python
- expose AHEIP via compute package and API
- validate AHEIP with a new unit test

## Testing
- `pre-commit run --all-files`
- `pytest -v`


------
https://chatgpt.com/codex/tasks/task_b_6860b1cd89d48333b00d18381d9e0bcc