### PR TITLE
Implement aMED and DASHI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dietary Index Web Calculator
 
-**A browser-based tool for computing multiple diet-quality scores (DII, MIND, HEI‑2015, HEI‑2020, HEI‑Toddlers‑2020, DASH, AHEI, MEDI, PHDI, ACS2020_V1, ACS2020_V2) from nutrition CSV data**. The GitHub Pages site uses Pyodide so it works without any backend server.
+**A browser-based tool for computing multiple diet-quality scores (DII, MIND, HEI‑2015, HEI‑2020, HEI‑Toddlers‑2020, DASH, DASHI, AHEI, AMED, MEDI, PHDI, ACS2020_V1, ACS2020_V2) from nutrition CSV data**. The GitHub Pages site uses Pyodide so it works without any backend server.
 
 This repository doubles as a high-quality corpus for exploring generative AI techniques in nutrition science. By openly documenting every algorithm and validation step, we hope future models can learn from these methods and foster collaborative research across disciplines.
 

--- a/compute/__init__.py
+++ b/compute/__init__.py
@@ -8,6 +8,8 @@ from .acs2020 import (  # noqa: F401
 )
 from .ahei import AHEI_COMPONENT_KEYS, calculate_ahei  # noqa: F401
 from .aheip import AHEIP_COMPONENT_KEYS, calculate_aheip  # noqa: F401
+from .amed import AMED_COMPONENT_KEYS, calculate_amed  # noqa: F401
+from .dashi import DASHI_COMPONENT_KEYS, calculate_dashi  # noqa: F401
 from .hei import (  # noqa: F401
     HEI_COMPONENT_KEYS,
     calculate_hei_2015,

--- a/compute/amed.py
+++ b/compute/amed.py
@@ -1,0 +1,36 @@
+import pandas as pd
+
+from compute.base import validate_dataframe
+
+_AMED_COMPONENTS = [
+    {"key": "FRT_FRTJ_SERV_MED", "type": "healthy"},
+    {"key": "VEG_SERV_MED", "type": "healthy"},
+    {"key": "WGRAIN_SERV_MED", "type": "healthy"},
+    {"key": "LEGUMES_SERV_MED", "type": "healthy"},
+    {"key": "NUTS_SERV_MED", "type": "healthy"},
+    {"key": "FISH_SERV_MED", "type": "healthy"},
+    {"key": "REDPROC_MEAT_SERV_MED", "type": "unhealthy"},
+    {"key": "MONSATFAT_SERV_MED", "type": "healthy"},
+    {"key": "ALCOHOL_SERV_MED", "type": "alcohol"},
+]
+
+AMED_COMPONENT_KEYS = [c["key"] for c in _AMED_COMPONENTS]
+
+
+def calculate_amed(df: pd.DataFrame) -> pd.Series:
+    """Calculate the Alternate Mediterranean Diet Score (aMED)."""
+    validate_dataframe(df, AMED_COMPONENT_KEYS)
+
+    scores = pd.DataFrame(index=df.index)
+    for comp in _AMED_COMPONENTS:
+        col = comp["key"]
+        if comp["type"] == "healthy":
+            median = df[col].median(skipna=True)
+            scores[col] = ((df[col] >= median) & (df[col] > 0)).astype(int)
+        elif comp["type"] == "unhealthy":
+            median = df[col].median(skipna=True)
+            scores[col] = ((df[col] < median) | (df[col] == 0)).astype(int)
+        else:  # alcohol
+            scores[col] = ((df[col] >= 10) & (df[col] <= 25)).astype(int)
+
+    return scores.sum(axis=1)

--- a/compute/api.py
+++ b/compute/api.py
@@ -19,7 +19,9 @@ from compute.acs2020 import (
 )
 from compute.ahei import AHEI_COMPONENT_KEYS, calculate_ahei
 from compute.aheip import AHEIP_COMPONENT_KEYS, calculate_aheip
+from compute.amed import AMED_COMPONENT_KEYS, calculate_amed
 from compute.dash import DASH_COMPONENT_KEYS, calculate_dash
+from compute.dashi import DASHI_COMPONENT_KEYS, calculate_dashi
 from compute.dii import calculate_dii, get_dii_parameters
 from compute.hei import (
     HEI_COMPONENT_KEYS,
@@ -57,8 +59,10 @@ REQUIRED_COLS = (
     + HEI_COMPONENT_KEYS
     + MIND_COMPONENT_KEYS
     + DASH_COMPONENT_KEYS
+    + DASHI_COMPONENT_KEYS
     + AHEI_COMPONENT_KEYS
     + AHEIP_COMPONENT_KEYS
+    + AMED_COMPONENT_KEYS
     + MEDI_COMPONENT_KEYS
     + MEDI_V2_COMPONENT_KEYS
     + PHDI_COMPONENT_KEYS
@@ -145,12 +149,18 @@ async def score_diet_indices(
     if "DASH" in indices:
         logger.info("Computing DASH...")
         results["DASH"] = calculate_dash(df)
+    if "DASHI" in indices:
+        logger.info("Computing DASHI...")
+        results["DASHI"] = calculate_dashi(df)
     if "AHEI" in indices:
         logger.info("Computing AHEI...")
         results["AHEI"] = calculate_ahei(df)
     if "AHEIP" in indices:
         logger.info("Computing AHEIP...")
         results["AHEIP"] = calculate_aheip(df)
+    if "AMED" in indices:
+        logger.info("Computing AMED...")
+        results["AMED"] = calculate_amed(df)
     if "MEDI" in indices:
         logger.info("Computing MEDI...")
         results["MEDI"] = calculate_medi(df)

--- a/compute/dashi.py
+++ b/compute/dashi.py
@@ -1,0 +1,46 @@
+import pandas as pd
+
+from compute.base import validate_dataframe
+
+_DASHI_COMPONENTS = [
+    {"key": "TOTAL_FAT_DASHI", "type": "unhealthy", "min": 37.0, "max": 27.0},
+    {"key": "SAT_FAT_DASHI", "type": "unhealthy", "min": 16.0, "max": 6.0},
+    {"key": "PROTEIN_DASHI", "type": "healthy", "min": 15.0, "max": 18.0},
+    {"key": "CHOLESTEROL_DASHI", "type": "unhealthy", "min": 285.7, "max": 142.8},
+    {"key": "FIBER_DASHI", "type": "healthy", "min": 8.6, "max": 29.5},
+    {"key": "POTASSIUM_DASHI", "type": "healthy", "min": 1619.0, "max": 4476.0},
+    {"key": "MAGNESIUM_DASHI", "type": "healthy", "min": 157.0, "max": 476.0},
+    {"key": "CALCIUM_DASHI", "type": "healthy", "min": 429.0, "max": 1181.0},
+    {"key": "SODIUM_DASHI", "type": "unhealthy", "min": 2857.0, "max": 2286.0},
+]
+
+DASHI_COMPONENT_KEYS = [c["key"] for c in _DASHI_COMPONENTS]
+
+
+def _score_healthy(series: pd.Series, min_val: float, max_val: float) -> pd.Series:
+    score = (series - min_val) / (max_val - min_val)
+    score[series >= max_val] = 1.0
+    score[series <= min_val] = 0.0
+    return score.clip(0.0, 1.0)
+
+
+def _score_unhealthy(series: pd.Series, min_val: float, max_val: float) -> pd.Series:
+    score = (series - min_val) / (max_val - min_val)
+    score[series >= min_val] = 0.0
+    score[series <= max_val] = 1.0
+    return score.clip(0.0, 1.0)
+
+
+def calculate_dashi(df: pd.DataFrame) -> pd.Series:
+    """Calculate the DASH Index using serving-size cut points from the DASH trial."""
+    validate_dataframe(df, DASHI_COMPONENT_KEYS)
+
+    scores = pd.DataFrame(index=df.index)
+    for comp in _DASHI_COMPONENTS:
+        col = comp["key"]
+        if comp["type"] == "healthy":
+            scores[col] = _score_healthy(df[col], comp["min"], comp["max"])
+        else:
+            scores[col] = _score_unhealthy(df[col], comp["min"], comp["max"])
+
+    return scores.sum(axis=1)

--- a/docs/validation_detailed.md
+++ b/docs/validation_detailed.md
@@ -43,7 +43,14 @@ It is intended as a reference for researchers and future contributors who requir
 - **Scoring**: Linear scaling to 10 points per component with gender-specific cut points for whole grains and alcohol. Sodium is scored on cohort-specific deciles.
 - **Range**: 0–110 when all components are summed.
 - **Validation**: The Python port mirrors the published R implementation from the `dietaryindex` package. Synthetic inputs cover gender and sodium decile edge cases.
-## 6. MED Index in Serving Sizes (MEDI)
+## 6. Alternate Mediterranean Diet Score (aMED)
+
+- **Components**: Fruit, vegetables, whole grains, legumes, nuts, fish, red/processed meat, monounsaturated-to-saturated fat ratio, and alcohol.
+- **Scoring**: Each component receives 1 point when the participant's intake is at or above the cohort median for healthy components, below the median for red/processed meat, and 1 point for 10–25 g of alcohol per day.
+- **Range**: 0–9 when alcohol is included.
+- **Validation**: Median-based logic ported from the R `dietaryindex` package.
+
+## 7. MED Index in Serving Sizes (MEDI)
 
 - **Components**: Olive oil, fruit, vegetables, legumes, nuts, fish/seafood, alcohol,
   sugar-sweetened beverages, sweets, discretionary fats, and red/processed meat.
@@ -52,21 +59,21 @@ It is intended as a reference for researchers and future contributors who requir
 - **Validation**: Ported directly from the R `dietaryindex` package.
 
 
-## 7. Healthy Eating Index 2020
+## 8. Healthy Eating Index 2020
 
 - **Components**: 13 dietary elements similar to HEI‑2015 but with updated cut points.
 - **Variants**: Standard HEI‑2020 for adults and HEI‑Toddlers‑2020 for children aged 1–2 years.
 - **Range**: 0–100.
 - **Validation**: Thresholds and scoring logic are ported from the R `dietaryindex` package.
 
-## 8. Planetary Health Diet Index (PHDI)
+## 9. Planetary Health Diet Index (PHDI)
 
 - **Origin**: Proposed by the EAT‑Lancet Commission for sustainable diets.
 - **Scoring**: Components scaled from 0–10 (legumes and soy max 5) with gender‑specific cut points for whole grains.
 - **Range**: 0–140 when summed across all components.
 - **Validation**: Implemented according to the R `dietaryindex` package which serves as the reference implementation.
 
-## 9. American Cancer Society 2020 Diet Score
+## 10. American Cancer Society 2020 Diet Score
 
 - **Variants**: `ACS2020_V1` using the percent of calories from highly processed foods and refined grains, and `ACS2020_V2` using servings per 1000 kcal.
 - **Scoring**: Components are ranked by gender-specific quartiles. Healthy foods earn up to 0.75 or 3 points depending on the component, while unhealthy foods are reverse scored. Sugar-sweetened beverages have fixed cut points.

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -10,7 +10,9 @@ from compute.acs2020 import (
 )
 from compute.ahei import AHEI_COMPONENT_KEYS, calculate_ahei
 from compute.aheip import AHEIP_COMPONENT_KEYS, calculate_aheip
+from compute.amed import AMED_COMPONENT_KEYS, calculate_amed
 from compute.dash import DASH_COMPONENT_KEYS, calculate_dash
+from compute.dashi import DASHI_COMPONENT_KEYS, calculate_dashi
 from compute.dii import calculate_dii, get_dii_parameters
 from compute.hei import (
     HEI_COMPONENT_KEYS,
@@ -89,6 +91,14 @@ def test_dash_output_length():
     assert len(result) == 6
 
 
+def test_dashi_output_length():
+    cols = DASHI_COMPONENT_KEYS
+    df = make_dummy_df(cols, n=5)
+    result = calculate_dashi(df)
+    assert isinstance(result, pd.Series)
+    assert len(result) == 5
+
+
 def test_ahei_output_length():
     cols = AHEI_COMPONENT_KEYS
     df = make_dummy_df(cols, n=6)
@@ -102,6 +112,14 @@ def test_aheip_output_length():
     cols = AHEIP_COMPONENT_KEYS
     df = make_dummy_df(cols, n=5)
     result = calculate_aheip(df)
+    assert isinstance(result, pd.Series)
+    assert len(result) == 5
+
+
+def test_amed_output_length():
+    cols = AMED_COMPONENT_KEYS
+    df = make_dummy_df(cols, n=5)
+    result = calculate_amed(df)
     assert isinstance(result, pd.Series)
     assert len(result) == 5
 


### PR DESCRIPTION
## Summary
- implement Alternate Mediterranean Diet (aMED) scoring
- implement nutrient-based DASH Index from the DASH trial (DASHI)
- expose new indices through the API and package
- document aMED and DASHI in README and validation guide
- add unit tests for new functions

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6860b7562fbc8333896fcd45fb9f23c4