### PR TITLE
Enhance pre-commit with pytest hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,11 @@ repos:
       - id: djlint
         args: ['--check']
         files: '\.html$'
+
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest -q
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The optional `setup.sh` script only installs dependencies for tests and the Pyth
   pytest tests/ --cov
   ```
 
-- **Pre-commit** hooks will run on `git commit` (black, isort, flake8).
+- **Pre-commit** hooks will run on `git commit` (black, isort, flake8, pytest).
 
 ---
 


### PR DESCRIPTION
## Summary
- enforce tests during pre-commit by adding a local pytest hook
- mention pytest in README pre-commit instructions

## Testing
- `pre-commit run --files .pre-commit-config.yaml README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6860ee6d077083338fce36ebe5ea6af4