### PR TITLE
Update docs with install steps for hooks

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -35,18 +35,17 @@ index.html                  # Single-page app served via GitHub Pages
 1. **Clone** the repository.
 2. **Open** `index.html` directly or serve it with `python -m http.server` to
    use the browser-only version.
-3. **Install** dependencies (for running tests or the optional library):
+3. **Install** dependencies and pre-commit hooks:
    ```bash
    pip install -r requirements.txt
+   pre-commit install
    ```
-4. **Run pre-commit** checks before committing:
+4. **Run pre-commit** checks before committing. The hook now runs the full
+   test suite along with formatting and linting:
    ```bash
    pre-commit run --all-files
    ```
-5. **Run tests**:
-   ```bash
-   pytest -v
-   ```
+   Manual `pytest` runs are optional because the hook covers them.
 
 ## API Endpoints
 - **POST** `/score`
@@ -58,6 +57,7 @@ index.html                  # Single-page app served via GitHub Pages
 - `black`: code formatting
 - `isort`: import sorting
 - `flake8`: linting (PEP8)
+- `pytest`: run the full test suite
 - `end-of-file-fixer`, `trailing-whitespace`
 - `check-added-large-files`: configured to exclude large data files with exclusions
 
@@ -73,6 +73,8 @@ When the AI agent runs, reference this file to:
 - Ship a default CSV template that loads automatically.
 - Document calculations and validation steps clearly.
 - Enforce code quality via pre-commit and pytest in CI.
+- Maintain reference validation datasets under `data/` with tests that
+  automatically run via the pre-commit hook.
 
 ## UI Standard
 - Keep note of "AGENT_STYLE.md" particularly built for OpenAI Codex

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ This repository doubles as a high-quality corpus for exploring generative AI tec
 Just open [https://dgd-strategies.github.io/dietarycodex](https://dgd-strategies.github.io/dietarycodex) or `index.html` locally. The page works fully client side and registers a service worker providing a demo endpoint `/api/time`.
 
 The optional `setup.sh` script only installs dependencies for tests and the Python library.
+If running commands manually, install the requirements and pre-commit hooks first:
+
+```bash
+pip install -r requirements.txt
+pre-commit install
+```
 
 ---
 
@@ -68,17 +74,21 @@ The optional `setup.sh` script only installs dependencies for tests and the Pyth
 
 - **Testing**:
 
-  ```bash
-  pytest tests/ --cov
-  ```
+```bash
+pytest tests/ --cov
+```
 
-- **Pre-commit** hooks will run on `git commit` (black, isort, flake8, pytest).
+- **Pre-commit** hooks run automatically on `git commit` and include the
+  complete pytest suite. You can trigger them manually as well:
+  ```bash
+  pre-commit run --all-files
+  ```
 
 ---
 
 ## Validation
 
-Detailed scoring methods, formulas, and reference citations are in [docs/validation\_detailed.md](docs/validation_detailed.md).
+Detailed scoring methods, formulas, and reference citations are in [docs/validation_detailed.md](docs/validation_detailed.md). Reference CSV files used for regression tests live under `data/` and are executed automatically whenever the pre-commit hook runs.
 
 ---
 
@@ -93,12 +103,9 @@ While the browser UI relies on Python via Pyodide, the scoring routines are bein
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on branching, testing, and PRs.
 
 ## Roadmap & OKRs
-These lightweight objectives keep development focused while ensuring the tool remains fully client side:
-
 - **Objective 1** – reliable scoring from a default template and drag‑and‑drop uploads across modern browsers.
 - **Objective 2** – clear documentation; methods live in [`validation.md`](validation.md) and [`docs/validation_detailed.md`](docs/validation_detailed.md).
 - **Objective 3** – code quality with pre‑commit and pytest enforced in CI.
-
 ---
 
 **License:** MIT

--- a/contributing.md
+++ b/contributing.md
@@ -16,6 +16,11 @@ Thank you for your interest in contributing! This guide outlines the workflow, s
    ```bash
    ./setup.sh --dev
    ```
+   If you prefer a manual setup, run:
+   ```bash
+   pip install -r requirements.txt
+   pre-commit install
+   ```
 
 ---
 
@@ -32,7 +37,8 @@ Thank you for your interest in contributing! This guide outlines the workflow, s
 
 - **Formatting & Linting**: Code is auto-formatted with **Black** and imports sorted with **isort**.
 - **Linting**: Ensure **flake8** passes with no errors or warnings.
-- **Pre-commit**: Hooks (black, isort, flake8, end-of-file-fixer) run on every `git commit`.
+- **Pre-commit**: Hooks run on every `git commit` and now include the
+  full pytest suite for validation in addition to black, isort, and flake8.
 - **Type Hints**: Use PEP 484 type annotations where appropriate.
 - **Docstrings**: Follow [Google style](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings).
 
@@ -68,7 +74,7 @@ This project follows the [Contributor Covenant](https://www.contributor-covenant
 
 - **README.md**: Project overview, setup, and usage.
 - **docs/validation\_detailed.md**: Scientific validation details for scoring methods.
-- **.pre-commit-config.yaml**: Pre-commit hook configuration.
+- **.pre-commit-config.yaml**: Pre-commit hook configuration (runs pytest and linters).
 - **pyproject.toml**: Black, isort, flake8, pytest configuration.
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -111,8 +111,15 @@ Download the master template for user uploads: [template.csv](../data/template.c
 
 ## Development Workflow
 
+- **Install** requirements and pre-commit hooks:
+  ```bash
+  pip install -r requirements.txt
+  pre-commit install
+  ```
 - **Formatting & Linting**: `make format`, `make lint`
 - **Testing**: `make test`
+- **Validation & Hooks**: `pre-commit run --all-files` will format, lint,
+  and execute the full test suite before commit.
 - **Optional API**: `make dev`
 - **CI**: GitHub Actions runs on push/PR (`.github/workflows/ci.yml`)
 

--- a/docs/okrs.md
+++ b/docs/okrs.md
@@ -11,6 +11,7 @@ This document outlines the **Objectives and Key Results** guiding ongoing develo
 ## Objective 2 – Solid Validation & Documentation
 - Provide clear instructions in the README and docs.
 - Document calculation methods in `validation.md` and `validation_detailed.md`.
+- Keep validation datasets under `data/` to enable automated regression tests.
 - Add examples and screenshots as features mature.
 
 ## Objective 3 – Code Quality & Automation

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,5 +1,4 @@
 # Validation Summary
 
-This page links to the detailed scientific references and methods used to verify
-each diet-quality index. For the full write-up see
+This page links to the detailed scientific references and methods used to verify each diet-quality index. Reference datasets live in the `data/` directory and are exercised automatically via the pre-commit hook. Install requirements first with `pip install -r requirements.txt`. For the full write-up see
 [../validation.md](../validation.md).

--- a/docs/validation_detailed.md
+++ b/docs/validation_detailed.md
@@ -99,5 +99,8 @@ It is intended as a reference for researchers and future contributors who requir
 2. **Integration tests** run the FastAPI endpoints against known datasets.
 3. **Statistical checks** compare summary statistics to those reported in the literature.
 4. **Visual diagnostics** (histograms and boxplots) ensure each score follows the expected shape.
+5. **Pre-commit**: Running `pre-commit run --all-files` executes these tests
+   automatically before code is committed. Ensure all requirements are installed
+   first with `pip install -r requirements.txt`.
 
 _This guide will evolve as additional datasets and language ports become available._


### PR DESCRIPTION
## Summary
- document installing requirements and pre-commit hook
- note manual setup in contributing guide
- add install instructions to docs and validation pages

## Testing
- `pre-commit run --files AGENT.md README.md contributing.md docs/index.md docs/validation.md docs/validation_detailed.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6860f0d773308333b5d43b868d63947c