### PR TITLE
Add FNDDS mapping helper

### DIFF
--- a/compute/__init__.py
+++ b/compute/__init__.py
@@ -21,6 +21,12 @@ from .hei import (  # noqa: F401
     calculate_hei_2020,
     calculate_hei_toddlers_2020,
 )
+from .mapping import (  # noqa: F401
+    USDA_DASH_MAP,
+    USDA_DII_MAP,
+    USDA_HEI_MAP,
+    apply_mapping,
+)
 from .medi import (  # noqa: F401
     MEDI_COMPONENT_KEYS,
     MEDI_V2_COMPONENT_KEYS,

--- a/compute/mapping.py
+++ b/compute/mapping.py
@@ -1,0 +1,76 @@
+"""Utilities for renaming common USDA/FNDDS columns.
+
+These mapping dictionaries translate raw column names often found in
+USDA or FNDDS exports to the standardized component names used
+throughout the scoring modules.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Mapping
+
+import pandas as pd
+
+# Example mappings for several indices -------------------------------------
+
+USDA_HEI_MAP: dict[str, str] = {
+    "F_TOTAL": "total_fruit_cup",
+    "F_CITMLB": "whole_fruit_cup",
+    "F_OTHER": "whole_fruit_cup",
+    "V_TOTAL": "total_veg_cup",
+    "V_LEGUMES": "greens_beans_cup",
+    "G_WHOLE": "whole_grains_oz",
+    "D_TOTAL": "dairy_cup",
+    "PF_TOTAL": "protein_oz",
+    "PF_SEAFD_HI": "seafood_plant_oz",
+    "PF_SEAFD_LOW": "seafood_plant_oz",
+    "PF_NUTSDS": "seafood_plant_oz",
+    "PF_SOY": "seafood_plant_oz",
+    "PF_LEGUMES": "seafood_plant_oz",
+    "KCAL": "energy_kcal",
+    "SODIUM": "sodium_mg",
+    "ADD_SUGARS": "added_sugars_g",
+}
+
+USDA_DASH_MAP: dict[str, str] = {
+    "F_TOTAL": "fruits_g",
+    "V_TOTAL": "vegetables_g",
+    "G_WHOLE": "whole_grains_g",
+    "D_TOTAL": "low_fat_dairy_g",
+    "PF_LEGUMES": "nuts_legumes_g",
+    "SODIUM": "sodium_mg",
+    "PROC_MEAT": "red_processed_meats_g",
+    "SLD_BEV": "sweetened_beverages_g",
+}
+
+USDA_DII_MAP: dict[str, str] = {
+    "ENERGY": "Energy",
+    "PROTEIN": "Protein",
+    "TOTALFAT": "Total fat",
+    "CARBOHYDRATE": "Carbohydrate",
+    "FIBER": "Fiber",
+    "FOLATE": "Folic acid",
+    "VITC": "Vitamin C",
+    "VITD": "Vitamin D",
+    "VITE": "Vitamin E",
+}
+
+# ---------------------------------------------------------------------------
+
+
+def apply_mapping(df: pd.DataFrame, mapping: Mapping[str, str]) -> pd.DataFrame:
+    """Rename DataFrame columns using a mapping and log unmatched fields."""
+
+    rename_map = {src: dst for src, dst in mapping.items() if src in df.columns}
+    missing = [src for src in mapping if src not in df.columns]
+    unmapped = [
+        col for col in df.columns if col not in rename_map and col not in mapping
+    ]
+
+    if missing:
+        logging.info("Unmapped source columns skipped: %s", sorted(missing))
+    if unmapped:
+        logging.info("Columns left unmapped: %s", sorted(unmapped))
+
+    return df.rename(columns=rename_map)

--- a/docs/README.md
+++ b/docs/README.md
@@ -107,6 +107,19 @@ Refer to our validation rules and scientific methods: [validation.md](validation
 
 Download the master template for user uploads: [template.csv](../data/template.csv)
 
+## Column Mapping
+
+Raw USDA or FNDDS exports often use different column names than the scoring modules.
+Use `compute.mapping.apply_mapping` to rename them automatically. Example:
+
+```python
+import pandas as pd
+from compute.mapping import USDA_HEI_MAP, apply_mapping
+
+df = pd.read_csv("fndds_export.csv")
+df = apply_mapping(df, USDA_HEI_MAP)
+```
+
 ---
 
 ## Development Workflow


### PR DESCRIPTION
## Summary
- provide dictionaries for common FNDDS column names
- expose `apply_mapping` function to rename dataframes and log unmatched columns
- export mapping helpers in the public package
- document how to use column mappings

## Testing
- `pre-commit run --files compute/__init__.py compute/mapping.py docs/README.md`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_b_686123154bf083338dd4d493a2eca316