### PR TITLE
Add column mapping workflow

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -107,6 +107,15 @@ Refer to our validation rules and scientific methods: [validation.md](validation
 
 Download the master template for user uploads: [template.csv](../data/template.csv)
 
+### Column Mapping
+
+When your CSV headers don't exactly match the expected names, the web app now
+prompts you to map them. After an initial upload, any unmatched required columns
+are listed with a dropdown of your file's headers. Select the appropriate source
+column for each requirement and click **Save Mapping**. The choices are stored in
+your browser's local storage so future uploads automatically rename columns
+before validation.
+
 ---
 
 ## Development Workflow

--- a/index.html
+++ b/index.html
@@ -189,6 +189,46 @@
       const lines = data.map(row => headers.map(h => row[h]).join(','));
       return [headers.join(','), ...lines].join('\n');
     }
+
+    function applyColumnMapping(data) {
+      const map = JSON.parse(localStorage.getItem('colMap') || '{}');
+      return data.map(row => {
+        const out = { ...row };
+        for (const [dst, src] of Object.entries(map)) {
+          if (src in row && !(dst in row)) {
+            out[dst] = row[src];
+          }
+        }
+        return out;
+      });
+    }
+
+    function showMappingUI(missing, headers) {
+      const saved = JSON.parse(localStorage.getItem('colMap') || '{}');
+      let html = '<h3>Map Columns</h3><form id="mapForm">';
+      missing.forEach(col => {
+        html += `<div class='mb-2'><label class='me-2'>${col}</label>`;
+        html += `<select class='form-select d-inline w-auto' data-key='${col}'>`;
+        html += "<option value=''>--</option>";
+        headers.forEach(h => {
+          const sel = saved[col] === h ? 'selected' : '';
+          html += `<option ${sel}>${h}</option>`;
+        });
+        html += '</select></div>';
+      });
+      html += "<button type='submit' class='btn btn-primary mt-2'>Save Mapping</button></form>";
+      resultBox.innerHTML = html;
+      document.getElementById('mapForm').addEventListener('submit', e => {
+        e.preventDefault();
+        const selects = document.querySelectorAll('#mapForm select');
+        selects.forEach(sel => {
+          if (sel.value) saved[sel.dataset.key] = sel.value;
+        });
+        localStorage.setItem('colMap', JSON.stringify(saved));
+        resultBox.innerHTML = '';
+        computeFile(currentData, currentName);
+      });
+    }
     dropzone.addEventListener('click', () => {
       const input = document.createElement('input');
       input.type = 'file';
@@ -258,8 +298,10 @@
     async function computeFile(data, name) {
       loading.style.display = 'block';
       try {
+        const headers = Object.keys(data[0] || {});
+        const mapped = applyColumnMapping(data);
         const py = await loadPy();
-        const jsonData = JSON.stringify(data).replace(/'/g, "\\'");
+        const jsonData = JSON.stringify(mapped).replace(/'/g, "\\'");
         const pyRes = await py.runPythonAsync(`
 import pandas as pd, json
 from compute.dii import calculate_dii, DII_PARAMETER_KEYS
@@ -321,7 +363,8 @@ json.dumps(out)
         const missing = info.missing || {};
         if (computed.length === 0) {
           const allMissing = [...new Set(Object.values(missing).flat())];
-          resultBox.innerHTML = `<div class='alert alert-danger'>Missing required columns (${allMissing.length}): ${allMissing.join(', ')}</div>`;
+          loading.style.display = 'none';
+          showMappingUI(allMissing, headers);
           return;
         }
         let summary = '<h3>Summary Statistics:</h3><ul>';


### PR DESCRIPTION
## Summary
- add dropdown-driven column mapping if headers don't match
- store mappings in local storage and apply automatically
- update docs on the new workflow

## Testing
- `pre-commit run --files index.html docs/README.md`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_b_68612319c3f08333877d0dfaec9247a7