### PR TITLE
Add HEI scorer and registry

### DIFF
--- a/rust/src/eval.rs
+++ b/rust/src/eval.rs
@@ -1,9 +1,9 @@
 use crate::nutrition_vector::NutritionVector;
-use crate::scores::{ahei::Ahei, DietScore};
+use crate::scores::{all_scorers, DietScore};
 use std::collections::HashMap;
 
 pub fn evaluate_all_scores(nv: &NutritionVector) -> HashMap<String, f64> {
-    let calculators: Vec<Box<dyn DietScore>> = vec![Box::new(Ahei)];
+    let calculators = all_scorers();
     let mut results = HashMap::new();
     for calc in calculators {
         let val = calc.score(nv);

--- a/rust/src/nutrition_vector.rs
+++ b/rust/src/nutrition_vector.rs
@@ -15,6 +15,9 @@ pub struct NutritionVector {
     pub calcium_mg: f64,
     pub iron_mg: f64,
     pub vitamin_c_mg: f64,
+    pub total_fruits_g: f64,
+    pub whole_grains_g: f64,
+    pub refined_grains_g: f64,
 }
 
 impl NutritionVector {
@@ -24,16 +27,20 @@ impl NutritionVector {
         if let Some(items) = v.get("foodNutrients").and_then(|v| v.as_array()) {
             let mut map: HashMap<&str, f64> = HashMap::new();
             for item in items {
-                if let (Some(nutrient), Some(amount)) =
-                    (item.get("nutrient"), item.get("amount"))
-                {
+                if let (Some(nutrient), Some(amount)) = (item.get("nutrient"), item.get("amount")) {
                     let name = nutrient.get("name").and_then(|n| n.as_str()).unwrap_or("");
-                    let unit = nutrient.get("unitName").and_then(|n| n.as_str()).unwrap_or("");
+                    let unit = nutrient
+                        .get("unitName")
+                        .and_then(|n| n.as_str())
+                        .unwrap_or("");
                     let amount = amount.as_f64().unwrap_or(0.0);
-                    map.insert(name, match unit.to_ascii_lowercase().as_str() {
-                        "mg" => amount / 1000.0,
-                        _ => amount,
-                    });
+                    map.insert(
+                        name,
+                        match unit.to_ascii_lowercase().as_str() {
+                            "mg" => amount / 1000.0,
+                            _ => amount,
+                        },
+                    );
                 }
             }
             nv.energy_kcal = *map.get("Energy").unwrap_or(&0.0);

--- a/rust/src/scores/hei.rs
+++ b/rust/src/scores/hei.rs
@@ -1,0 +1,27 @@
+use super::DietScore;
+use crate::nutrition_vector::NutritionVector;
+
+pub struct HeiScorer;
+
+impl DietScore for HeiScorer {
+    fn score(&self, nv: &NutritionVector) -> f64 {
+        let mut score = 0.0;
+        // fruit component: 0-10 points with 200g threshold
+        score += (nv.total_fruits_g / 200.0 * 10.0).clamp(0.0, 10.0);
+        // whole grains component: 0-10 points with 75g threshold
+        score += (nv.whole_grains_g / 75.0 * 10.0).clamp(0.0, 10.0);
+        // sodium moderation: linear 10 points at <=1500 mg down to 0 at 2300 mg
+        let sodium_score = if nv.sodium_mg <= 1500.0 {
+            10.0
+        } else if nv.sodium_mg >= 2300.0 {
+            0.0
+        } else {
+            (2300.0 - nv.sodium_mg) / (2300.0 - 1500.0) * 10.0
+        };
+        score + sodium_score
+    }
+
+    fn name(&self) -> &'static str {
+        "HEI"
+    }
+}

--- a/rust/src/scores/mod.rs
+++ b/rust/src/scores/mod.rs
@@ -6,3 +6,7 @@ pub trait DietScore {
 }
 
 pub mod ahei;
+pub mod hei;
+pub mod registry;
+
+pub use registry::all_scorers;

--- a/rust/src/scores/registry.rs
+++ b/rust/src/scores/registry.rs
@@ -1,0 +1,5 @@
+use super::{ahei::Ahei, hei::HeiScorer, DietScore};
+
+pub fn all_scorers() -> Vec<Box<dyn DietScore>> {
+    vec![Box::new(Ahei), Box::new(HeiScorer)]
+}

--- a/rust/tests/score_tests.rs
+++ b/rust/tests/score_tests.rs
@@ -1,0 +1,16 @@
+use dietarycodex::nutrition_vector::NutritionVector;
+use dietarycodex::scores::hei::HeiScorer;
+use dietarycodex::scores::DietScore;
+
+#[test]
+fn hei_score_not_nan() {
+    let nv = NutritionVector {
+        total_fruits_g: 150.0,
+        whole_grains_g: 80.0,
+        sodium_mg: 1600.0,
+        ..Default::default()
+    };
+    let scorer = HeiScorer;
+    let val = scorer.score(&nv);
+    assert!(!val.is_nan());
+}


### PR DESCRIPTION
## Summary
- implement `HeiScorer` using existing `DietScore` trait
- introduce `scores::registry` for central scorer registration
- expose new modules and registry in `scores::mod`
- extend `NutritionVector` with grain/fruit fields
- update evaluation logic to gather scorers from the registry
- add a small test for `HeiScorer`

## Testing
- `cargo test`
- `pre-commit run --files rust/src/nutrition_vector.rs rust/src/scores/hei.rs rust/src/scores/registry.rs rust/src/scores/mod.rs rust/src/eval.rs rust/tests/score_tests.rs`

------
https://chatgpt.com/codex/tasks/task_b_686135f976b883338de8edc4e98e0c68