### PR TITLE
Add DASH scoring to Rust module

### DIFF
--- a/rust/src/nutrition_vector.rs
+++ b/rust/src/nutrition_vector.rs
@@ -16,6 +16,7 @@ pub struct NutritionVector {
     pub iron_mg: f64,
     pub vitamin_c_mg: f64,
     pub total_fruits_g: f64,
+    pub vegetables_g: f64,
     pub whole_grains_g: f64,
     pub refined_grains_g: f64,
 }

--- a/rust/src/scores/dash.rs
+++ b/rust/src/scores/dash.rs
@@ -1,0 +1,36 @@
+use super::DietScore;
+use crate::nutrition_vector::NutritionVector;
+
+pub struct DashScorer;
+
+impl DietScore for DashScorer {
+    fn score(&self, nv: &NutritionVector) -> f64 {
+        let fruit = (nv.total_fruits_g / 400.0 * 10.0).clamp(0.0, 10.0);
+        let veg = (nv.vegetables_g / 400.0 * 10.0).clamp(0.0, 10.0);
+        let grains = (nv.whole_grains_g / 75.0 * 10.0).clamp(0.0, 10.0);
+        let sodium = if nv.sodium_mg <= 1500.0 {
+            10.0
+        } else if nv.sodium_mg >= 2300.0 {
+            0.0
+        } else {
+            (2300.0 - nv.sodium_mg) / (2300.0 - 1500.0) * 10.0
+        };
+        let sat_percent = if nv.energy_kcal > 0.0 {
+            (nv.saturated_fat_g * 9.0) / nv.energy_kcal * 100.0
+        } else {
+            0.0
+        };
+        let sat_fat = if sat_percent <= 5.0 {
+            10.0
+        } else if sat_percent >= 15.0 {
+            0.0
+        } else {
+            (15.0 - sat_percent) / (15.0 - 5.0) * 10.0
+        };
+        fruit + veg + grains + sodium + sat_fat
+    }
+
+    fn name(&self) -> &'static str {
+        "DASH"
+    }
+}

--- a/rust/src/scores/mod.rs
+++ b/rust/src/scores/mod.rs
@@ -6,6 +6,7 @@ pub trait DietScore {
 }
 
 pub mod ahei;
+pub mod dash;
 pub mod hei;
 pub mod registry;
 

--- a/rust/src/scores/registry.rs
+++ b/rust/src/scores/registry.rs
@@ -1,5 +1,5 @@
-use super::{ahei::Ahei, hei::HeiScorer, DietScore};
+use super::{ahei::Ahei, dash::DashScorer, hei::HeiScorer, DietScore};
 
 pub fn all_scorers() -> Vec<Box<dyn DietScore>> {
-    vec![Box::new(Ahei), Box::new(HeiScorer)]
+    vec![Box::new(Ahei), Box::new(HeiScorer), Box::new(DashScorer)]
 }

--- a/rust/tests/score_tests.rs
+++ b/rust/tests/score_tests.rs
@@ -1,4 +1,6 @@
+use dietarycodex::eval::evaluate_all_scores;
 use dietarycodex::nutrition_vector::NutritionVector;
+use dietarycodex::scores::dash::DashScorer;
 use dietarycodex::scores::hei::HeiScorer;
 use dietarycodex::scores::DietScore;
 
@@ -13,4 +15,35 @@ fn hei_score_not_nan() {
     let scorer = HeiScorer;
     let val = scorer.score(&nv);
     assert!(!val.is_nan());
+}
+
+#[test]
+fn dash_score_not_nan() {
+    let nv = NutritionVector {
+        total_fruits_g: 200.0,
+        vegetables_g: 250.0,
+        whole_grains_g: 80.0,
+        sodium_mg: 1600.0,
+        saturated_fat_g: 10.0,
+        energy_kcal: 2000.0,
+        ..Default::default()
+    };
+    let scorer = DashScorer;
+    let val = scorer.score(&nv);
+    assert!(!val.is_nan());
+}
+
+#[test]
+fn evaluate_returns_dash() {
+    let nv = NutritionVector {
+        total_fruits_g: 200.0,
+        vegetables_g: 200.0,
+        whole_grains_g: 80.0,
+        sodium_mg: 1600.0,
+        saturated_fat_g: 10.0,
+        energy_kcal: 2000.0,
+        ..Default::default()
+    };
+    let scores = evaluate_all_scores(&nv);
+    assert!(scores.contains_key("DASH"));
 }


### PR DESCRIPTION
## Summary
- implement new `DashScorer`
- expose module and register scorer
- support vegetables input in `NutritionVector`
- add tests confirming DASH integration

## Testing
- `pre-commit run --files rust/src/scores/dash.rs rust/src/scores/registry.rs rust/src/scores/mod.rs rust/src/nutrition_vector.rs rust/tests/score_tests.rs`
- `cargo test --manifest-path rust/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_b_686137bc6c808333804f4548601ce72d