### PR TITLE
Add aMED scorer

### DIFF
--- a/rust/src/nutrition_vector.rs
+++ b/rust/src/nutrition_vector.rs
@@ -19,6 +19,10 @@ pub struct NutritionVector {
     pub vegetables_g: f64,
     pub whole_grains_g: f64,
     pub refined_grains_g: f64,
+    pub legumes_g: f64,
+    pub fish_g: f64,
+    pub red_meat_g: f64,
+    pub mono_fat_g: f64,
 }
 
 impl NutritionVector {

--- a/rust/src/scores/amed.rs
+++ b/rust/src/scores/amed.rs
@@ -1,0 +1,22 @@
+use super::{capped_score, DietScore};
+use crate::nutrition_vector::NutritionVector;
+
+pub struct AMedScorer;
+
+impl DietScore for AMedScorer {
+    fn score(&self, nv: &NutritionVector) -> f64 {
+        let veg = capped_score(nv.vegetables_g, 300.0);
+        let legumes = capped_score(nv.legumes_g, 100.0);
+        let fruit = capped_score(nv.total_fruits_g, 200.0);
+        let grains = capped_score(nv.whole_grains_g, 75.0);
+        let fish = capped_score(nv.fish_g, 100.0);
+        let mono_fat = capped_score(nv.mono_fat_g, 25.0);
+        let red_meat = (10.0 - capped_score(nv.red_meat_g, 100.0)).clamp(0.0, 10.0);
+        // Placeholder: alcohol component omitted for now
+        veg + legumes + fruit + grains + fish + mono_fat + red_meat
+    }
+
+    fn name(&self) -> &'static str {
+        "aMED"
+    }
+}

--- a/rust/src/scores/mod.rs
+++ b/rust/src/scores/mod.rs
@@ -5,7 +5,12 @@ pub trait DietScore {
     fn name(&self) -> &'static str;
 }
 
+pub fn capped_score(value: f64, max: f64) -> f64 {
+    (value / max * 10.0).clamp(0.0, 10.0)
+}
+
 pub mod ahei;
+pub mod amed;
 pub mod dash;
 pub mod hei;
 pub mod registry;

--- a/rust/src/scores/registry.rs
+++ b/rust/src/scores/registry.rs
@@ -1,5 +1,10 @@
-use super::{ahei::Ahei, dash::DashScorer, hei::HeiScorer, DietScore};
+use super::{ahei::Ahei, amed::AMedScorer, dash::DashScorer, hei::HeiScorer, DietScore};
 
 pub fn all_scorers() -> Vec<Box<dyn DietScore>> {
-    vec![Box::new(Ahei), Box::new(HeiScorer), Box::new(DashScorer)]
+    vec![
+        Box::new(Ahei),
+        Box::new(HeiScorer),
+        Box::new(DashScorer),
+        Box::new(AMedScorer),
+    ]
 }

--- a/rust/tests/score_tests.rs
+++ b/rust/tests/score_tests.rs
@@ -1,5 +1,6 @@
 use dietarycodex::eval::evaluate_all_scores;
 use dietarycodex::nutrition_vector::NutritionVector;
+use dietarycodex::scores::amed::AMedScorer;
 use dietarycodex::scores::dash::DashScorer;
 use dietarycodex::scores::hei::HeiScorer;
 use dietarycodex::scores::DietScore;
@@ -29,6 +30,23 @@ fn dash_score_not_nan() {
         ..Default::default()
     };
     let scorer = DashScorer;
+    let val = scorer.score(&nv);
+    assert!(!val.is_nan());
+}
+
+#[test]
+fn amed_score_not_nan() {
+    let nv = NutritionVector {
+        vegetables_g: 250.0,
+        legumes_g: 100.0,
+        total_fruits_g: 150.0,
+        whole_grains_g: 80.0,
+        fish_g: 80.0,
+        mono_fat_g: 30.0,
+        red_meat_g: 50.0,
+        ..Default::default()
+    };
+    let scorer = AMedScorer;
     let val = scorer.score(&nv);
     assert!(!val.is_nan());
 }


### PR DESCRIPTION
## Summary
- implement aMED scoring module and register it
- expose helper `capped_score` utility
- extend `NutritionVector` for Mediterranean components
- add unit test for aMED scorer

## Testing
- `pre-commit run --all-files`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_6861398c5abc8333ae1c3eecfd4c888b