### PR TITLE
Add ACS2020 diet score

### DIFF
--- a/rust/src/nutrition_vector.rs
+++ b/rust/src/nutrition_vector.rs
@@ -31,6 +31,7 @@ pub struct NutritionVector {
     pub selenium_mcg: f64,
     pub magnesium_mg: f64,
     pub trans_fat_g: f64,
+    pub alcohol_g: f64,
 }
 
 impl NutritionVector {
@@ -74,6 +75,7 @@ impl NutritionVector {
             nv.selenium_mcg = *map.get("Selenium, Se").unwrap_or(&0.0);
             nv.magnesium_mg = map.get("Magnesium, Mg").unwrap_or(&0.0) * 1000.0;
             nv.trans_fat_g = *map.get("Fatty acids, total trans").unwrap_or(&0.0);
+            nv.alcohol_g = *map.get("Alcohol, ethyl").unwrap_or(&0.0);
         }
         Ok(nv)
     }

--- a/rust/src/scores/acs2020.rs
+++ b/rust/src/scores/acs2020.rs
@@ -1,0 +1,21 @@
+use super::{capped_score, DietScore};
+use crate::nutrition_vector::NutritionVector;
+
+pub struct Acs2020Scorer;
+
+impl DietScore for Acs2020Scorer {
+    fn score(&self, nv: &NutritionVector) -> f64 {
+        let veg = capped_score(nv.vegetables_g, 300.0);
+        let fruit = capped_score(nv.total_fruits_g, 200.0);
+        let legumes = capped_score(nv.legumes_g, 100.0);
+        let grains = capped_score(nv.whole_grains_g, 75.0);
+        let red_meat = (10.0 - capped_score(nv.red_meat_g, 100.0)).clamp(0.0, 10.0);
+        let sugar = (10.0 - capped_score(nv.sugar_g, 50.0)).clamp(0.0, 10.0);
+        let alcohol = (10.0 - capped_score(nv.alcohol_g, 20.0)).clamp(0.0, 10.0);
+        veg + fruit + legumes + grains + red_meat + sugar + alcohol
+    }
+
+    fn name(&self) -> &'static str {
+        "ACS2020"
+    }
+}

--- a/rust/src/scores/mod.rs
+++ b/rust/src/scores/mod.rs
@@ -14,6 +14,7 @@ pub mod amed;
 pub mod dash;
 pub mod dii;
 pub mod hei;
+pub mod acs2020;
 pub mod registry;
 
 pub use registry::all_scorers;

--- a/rust/src/scores/registry.rs
+++ b/rust/src/scores/registry.rs
@@ -1,4 +1,7 @@
-use super::{ahei::Ahei, amed::AMedScorer, dash::DashScorer, dii::DiiScorer, hei::HeiScorer, DietScore};
+use super::{
+    acs2020::Acs2020Scorer, ahei::Ahei, amed::AMedScorer, dash::DashScorer, dii::DiiScorer,
+    hei::HeiScorer, DietScore,
+};
 
 pub fn all_scorers() -> Vec<Box<dyn DietScore>> {
     vec![
@@ -7,5 +10,6 @@ pub fn all_scorers() -> Vec<Box<dyn DietScore>> {
         Box::new(DashScorer),
         Box::new(AMedScorer),
         Box::new(DiiScorer),
+        Box::new(Acs2020Scorer),
     ]
 }

--- a/rust/tests/score_tests.rs
+++ b/rust/tests/score_tests.rs
@@ -5,6 +5,7 @@ use dietarycodex::scores::dash::DashScorer;
 use dietarycodex::scores::hei::HeiScorer;
 use dietarycodex::scores::DietScore;
 use dietarycodex::scores::dii::DiiScorer;
+use dietarycodex::scores::acs2020::Acs2020Scorer;
 
 #[test]
 fn hei_score_not_nan() {
@@ -88,4 +89,28 @@ fn evaluate_returns_dii() {
     let scorer = DiiScorer;
     let val = scorer.score(&nv);
     assert!(!val.is_nan());
+}
+
+#[test]
+fn acs2020_score_not_nan() {
+    let nv = NutritionVector {
+        vegetables_g: 250.0,
+        legumes_g: 90.0,
+        total_fruits_g: 180.0,
+        whole_grains_g: 80.0,
+        red_meat_g: 40.0,
+        sugar_g: 30.0,
+        alcohol_g: 10.0,
+        ..Default::default()
+    };
+    let scorer = Acs2020Scorer;
+    let val = scorer.score(&nv);
+    assert!(!val.is_nan());
+}
+
+#[test]
+fn evaluate_returns_acs2020() {
+    let nv = NutritionVector::default();
+    let scores = evaluate_all_scores(&nv);
+    assert!(scores.contains_key("ACS2020"));
 }


### PR DESCRIPTION
## Summary
- implement `Acs2020Scorer` for American Cancer Society 2020 guidelines
- register the scorer and expose it through the public API
- extend `NutritionVector` with `alcohol_g`
- test ACS2020 scorer and registry

## Testing
- `cargo test`
- `pre-commit run --files rust/src/nutrition_vector.rs rust/src/scores/acs2020.rs rust/src/scores/mod.rs rust/src/scores/registry.rs rust/tests/score_tests.rs`

------
https://chatgpt.com/codex/tasks/task_b_68613d851d188333b128363cc49093c9