### PR TITLE
Add Planetary Health Diet Index scorer

### DIFF
--- a/rust/src/scores/mod.rs
+++ b/rust/src/scores/mod.rs
@@ -15,6 +15,7 @@ pub mod dash;
 pub mod dii;
 pub mod hei;
 pub mod acs2020;
+pub mod phdi;
 pub mod registry;
 
 pub use registry::all_scorers;

--- a/rust/src/scores/phdi.rs
+++ b/rust/src/scores/phdi.rs
@@ -1,0 +1,28 @@
+use super::{capped_score, DietScore};
+use crate::nutrition_vector::NutritionVector;
+
+pub struct PhdiScorer;
+
+impl DietScore for PhdiScorer {
+    fn score(&self, nv: &NutritionVector) -> f64 {
+        let veg = capped_score(nv.vegetables_g, 300.0);
+        let legumes = capped_score(nv.legumes_g, 100.0);
+        let grains = capped_score(nv.whole_grains_g, 90.0);
+        let unsat_fat_g = (nv.fat_g - nv.saturated_fat_g - nv.trans_fat_g).max(0.0);
+        let unsat_fat = capped_score(unsat_fat_g, 20.0);
+        let red_meat = (10.0 - capped_score(nv.red_meat_g, 100.0)).clamp(0.0, 10.0);
+        let sugar = (10.0 - capped_score(nv.sugar_g, 50.0)).clamp(0.0, 10.0);
+        let refined = (10.0 - capped_score(nv.refined_grains_g, 150.0)).clamp(0.0, 10.0);
+        let energy = if nv.energy_kcal >= 1500.0 && nv.energy_kcal <= 2500.0 {
+            10.0
+        } else {
+            0.0
+        };
+
+        veg + legumes + grains + unsat_fat + red_meat + sugar + refined + energy
+    }
+
+    fn name(&self) -> &'static str {
+        "PHDI"
+    }
+}

--- a/rust/src/scores/registry.rs
+++ b/rust/src/scores/registry.rs
@@ -1,6 +1,6 @@
 use super::{
     acs2020::Acs2020Scorer, ahei::Ahei, amed::AMedScorer, dash::DashScorer, dii::DiiScorer,
-    hei::HeiScorer, DietScore,
+    hei::HeiScorer, phdi::PhdiScorer, DietScore,
 };
 
 pub fn all_scorers() -> Vec<Box<dyn DietScore>> {
@@ -10,6 +10,7 @@ pub fn all_scorers() -> Vec<Box<dyn DietScore>> {
         Box::new(DashScorer),
         Box::new(AMedScorer),
         Box::new(DiiScorer),
+        Box::new(PhdiScorer),
         Box::new(Acs2020Scorer),
     ]
 }

--- a/rust/tests/score_tests.rs
+++ b/rust/tests/score_tests.rs
@@ -6,6 +6,7 @@ use dietarycodex::scores::hei::HeiScorer;
 use dietarycodex::scores::DietScore;
 use dietarycodex::scores::dii::DiiScorer;
 use dietarycodex::scores::acs2020::Acs2020Scorer;
+use dietarycodex::scores::phdi::PhdiScorer;
 
 #[test]
 fn hei_score_not_nan() {
@@ -113,4 +114,31 @@ fn evaluate_returns_acs2020() {
     let nv = NutritionVector::default();
     let scores = evaluate_all_scores(&nv);
     assert!(scores.contains_key("ACS2020"));
+}
+
+#[test]
+fn phdi_score_not_nan() {
+    let nv = NutritionVector {
+        vegetables_g: 250.0,
+        legumes_g: 80.0,
+        whole_grains_g: 70.0,
+        fat_g: 40.0,
+        saturated_fat_g: 10.0,
+        trans_fat_g: 0.5,
+        red_meat_g: 20.0,
+        sugar_g: 30.0,
+        refined_grains_g: 100.0,
+        energy_kcal: 2000.0,
+        ..Default::default()
+    };
+    let scorer = PhdiScorer;
+    let val = scorer.score(&nv);
+    assert!(!val.is_nan());
+}
+
+#[test]
+fn evaluate_returns_phdi() {
+    let nv = NutritionVector::default();
+    let scores = evaluate_all_scores(&nv);
+    assert!(scores.contains_key("PHDI"));
 }


### PR DESCRIPTION
## Summary
- implement `PhdiScorer` for the Planetary Health Diet Index
- register PHDI in the score registry
- expose module via `scores::phdi`
- verify new scorer in unit tests

## Testing
- `pre-commit run --files rust/src/scores/mod.rs rust/src/scores/phdi.rs rust/src/scores/registry.rs rust/tests/score_tests.rs`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_b_68613f8c6ecc8333954550ebe0113bc0