### PR TITLE
Add DASHI and MIND diet scorers in Rust

### DIFF
--- a/rust/src/nutrition_vector.rs
+++ b/rust/src/nutrition_vector.rs
@@ -23,6 +23,12 @@ pub struct NutritionVector {
     pub fish_g: f64,
     pub red_meat_g: f64,
     pub mono_fat_g: f64,
+    pub berries_g: f64,
+    pub cheese_g: f64,
+    pub butter_g: f64,
+    pub poultry_g: f64,
+    pub fast_food_g: f64,
+    pub nuts_g: f64,
     // Additional nutrients for indices like DII
     pub omega3_g: f64,
     pub vitamin_a_mcg: f64,

--- a/rust/src/scores/dashi.rs
+++ b/rust/src/scores/dashi.rs
@@ -1,0 +1,25 @@
+use super::{capped_score, DietScore};
+use crate::nutrition_vector::NutritionVector;
+
+pub struct DashiScorer;
+
+impl DietScore for DashiScorer {
+    fn score(&self, nv: &NutritionVector) -> f64 {
+        let veg = capped_score(nv.vegetables_g, 400.0) / 5.0;
+        let fruit = capped_score(nv.total_fruits_g, 400.0) / 5.0;
+        let dairy = capped_score(nv.calcium_mg, 1000.0) / 5.0;
+        let grains = capped_score(nv.whole_grains_g, 75.0) / 5.0;
+        let sodium = if nv.sodium_mg <= 1500.0 {
+            2.0
+        } else if nv.sodium_mg >= 2300.0 {
+            0.0
+        } else {
+            (2300.0 - nv.sodium_mg) / (2300.0 - 1500.0) * 2.0
+        };
+        veg + fruit + dairy + grains + sodium
+    }
+
+    fn name(&self) -> &'static str {
+        "DASHI"
+    }
+}

--- a/rust/src/scores/mind.rs
+++ b/rust/src/scores/mind.rs
@@ -1,0 +1,39 @@
+use super::{capped_score, DietScore};
+use crate::nutrition_vector::NutritionVector;
+
+pub struct MindScorer;
+
+impl DietScore for MindScorer {
+    fn score(&self, nv: &NutritionVector) -> f64 {
+        let leafy = capped_score(nv.vegetables_g, 100.0) / 10.0;
+        let berries = capped_score(nv.berries_g, 50.0) / 10.0;
+        let nuts = capped_score(nv.nuts_g, 30.0) / 10.0;
+        let grains = capped_score(nv.whole_grains_g, 60.0) / 10.0;
+        let fish = capped_score(nv.fish_g, 100.0) / 10.0;
+        let poultry = capped_score(nv.poultry_g, 100.0) / 10.0;
+        let olive_oil = capped_score(nv.mono_fat_g, 20.0) / 10.0;
+
+        let red_meat = (1.0 - capped_score(nv.red_meat_g, 100.0) / 10.0).clamp(0.0, 1.0);
+        let fast_food = (1.0 - capped_score(nv.fast_food_g, 100.0) / 10.0).clamp(0.0, 1.0);
+        let sweets = (1.0 - capped_score(nv.sugar_g, 50.0) / 10.0).clamp(0.0, 1.0);
+        let cheese = (1.0 - capped_score(nv.cheese_g, 50.0) / 10.0).clamp(0.0, 1.0);
+        let butter = (1.0 - capped_score(nv.butter_g, 20.0) / 10.0).clamp(0.0, 1.0);
+
+        leafy
+            + berries
+            + nuts
+            + grains
+            + fish
+            + poultry
+            + olive_oil
+            + red_meat
+            + fast_food
+            + sweets
+            + cheese
+            + butter
+    }
+
+    fn name(&self) -> &'static str {
+        "MIND"
+    }
+}

--- a/rust/src/scores/mod.rs
+++ b/rust/src/scores/mod.rs
@@ -12,10 +12,12 @@ pub fn capped_score(value: f64, max: f64) -> f64 {
 pub mod ahei;
 pub mod amed;
 pub mod dash;
+pub mod dashi;
 pub mod dii;
 pub mod hei;
 pub mod acs2020;
 pub mod phdi;
+pub mod mind;
 pub mod registry;
 
 pub use registry::all_scorers;

--- a/rust/src/scores/registry.rs
+++ b/rust/src/scores/registry.rs
@@ -1,6 +1,7 @@
 use super::{
-    acs2020::Acs2020Scorer, ahei::Ahei, amed::AMedScorer, dash::DashScorer, dii::DiiScorer,
-    hei::HeiScorer, phdi::PhdiScorer, DietScore,
+    acs2020::Acs2020Scorer, ahei::Ahei, amed::AMedScorer, dash::DashScorer,
+    dashi::DashiScorer, dii::DiiScorer, hei::HeiScorer, mind::MindScorer,
+    phdi::PhdiScorer, DietScore,
 };
 
 pub fn all_scorers() -> Vec<Box<dyn DietScore>> {
@@ -8,9 +9,11 @@ pub fn all_scorers() -> Vec<Box<dyn DietScore>> {
         Box::new(Ahei),
         Box::new(HeiScorer),
         Box::new(DashScorer),
+        Box::new(DashiScorer),
         Box::new(AMedScorer),
         Box::new(DiiScorer),
         Box::new(PhdiScorer),
         Box::new(Acs2020Scorer),
+        Box::new(MindScorer),
     ]
 }

--- a/rust/tests/score_tests.rs
+++ b/rust/tests/score_tests.rs
@@ -2,10 +2,12 @@ use dietarycodex::eval::evaluate_all_scores;
 use dietarycodex::nutrition_vector::NutritionVector;
 use dietarycodex::scores::amed::AMedScorer;
 use dietarycodex::scores::dash::DashScorer;
+use dietarycodex::scores::dashi::DashiScorer;
 use dietarycodex::scores::hei::HeiScorer;
 use dietarycodex::scores::DietScore;
 use dietarycodex::scores::dii::DiiScorer;
 use dietarycodex::scores::acs2020::Acs2020Scorer;
+use dietarycodex::scores::mind::MindScorer;
 use dietarycodex::scores::phdi::PhdiScorer;
 
 #[test]
@@ -33,6 +35,21 @@ fn dash_score_not_nan() {
         ..Default::default()
     };
     let scorer = DashScorer;
+    let val = scorer.score(&nv);
+    assert!(!val.is_nan());
+}
+
+#[test]
+fn dashi_score_not_nan() {
+    let nv = NutritionVector {
+        vegetables_g: 250.0,
+        total_fruits_g: 250.0,
+        whole_grains_g: 80.0,
+        calcium_mg: 900.0,
+        sodium_mg: 1600.0,
+        ..Default::default()
+    };
+    let scorer = DashiScorer;
     let val = scorer.score(&nv);
     assert!(!val.is_nan());
 }
@@ -67,6 +84,13 @@ fn evaluate_returns_dash() {
     };
     let scores = evaluate_all_scores(&nv);
     assert!(scores.contains_key("DASH"));
+}
+
+#[test]
+fn evaluate_returns_dashi() {
+    let nv = NutritionVector::default();
+    let scores = evaluate_all_scores(&nv);
+    assert!(scores.contains_key("DASHI"));
 }
 
 #[test]
@@ -141,4 +165,33 @@ fn evaluate_returns_phdi() {
     let nv = NutritionVector::default();
     let scores = evaluate_all_scores(&nv);
     assert!(scores.contains_key("PHDI"));
+}
+
+#[test]
+fn mind_score_not_nan() {
+    let nv = NutritionVector {
+        vegetables_g: 150.0,
+        berries_g: 40.0,
+        nuts_g: 20.0,
+        whole_grains_g: 60.0,
+        fish_g: 50.0,
+        poultry_g: 80.0,
+        mono_fat_g: 25.0,
+        red_meat_g: 20.0,
+        sugar_g: 15.0,
+        cheese_g: 10.0,
+        butter_g: 5.0,
+        fast_food_g: 0.0,
+        ..Default::default()
+    };
+    let scorer = MindScorer;
+    let val = scorer.score(&nv);
+    assert!(!val.is_nan());
+}
+
+#[test]
+fn evaluate_returns_mind() {
+    let nv = NutritionVector::default();
+    let scores = evaluate_all_scores(&nv);
+    assert!(scores.contains_key("MIND"));
 }


### PR DESCRIPTION
## Summary
- implement new `DashiScorer` and `MindScorer`
- expose new scorers and register them for evaluation
- extend `NutritionVector` with fields needed for MIND
- test that new scorers work and appear in results

## Testing
- `pre-commit run --all-files`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_b_6861424e6e8c833381d74b4e4bb8a539