### PR TITLE
Refactor Rust score API

### DIFF
--- a/rust/src/eval.rs
+++ b/rust/src/eval.rs
@@ -1,13 +1,31 @@
 use crate::nutrition_vector::NutritionVector;
 use crate::scores::all_scorers;
+use serde::Serialize;
 use std::collections::HashMap;
 
-pub fn evaluate_all_scores(nv: &NutritionVector) -> HashMap<String, f64> {
+#[derive(Debug, Serialize)]
+pub struct ScoreResult {
+    pub scores: HashMap<String, f64>,
+    pub ordered_names: Vec<String>,
+}
+
+pub fn evaluate_all_scores(nv: &NutritionVector) -> ScoreResult {
     let calculators = all_scorers();
     let mut results = HashMap::new();
+    let mut ordered = Vec::new();
     for calc in calculators {
+        let name = calc.name().to_string();
         let val = calc.score(nv);
-        results.insert(calc.name().to_string(), val);
+        ordered.push(name.clone());
+        results.insert(name, val);
     }
-    results
+    ScoreResult {
+        scores: results,
+        ordered_names: ordered,
+    }
+}
+
+pub fn print_scores_as_json(nv: &NutritionVector) -> String {
+    let result = evaluate_all_scores(nv);
+    serde_json::to_string_pretty(&result).unwrap_or_else(|_| "{}".to_string())
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,4 +1,4 @@
-use dietarycodex::eval::evaluate_all_scores;
+use dietarycodex::eval::print_scores_as_json;
 use dietarycodex::nutrition_vector::NutritionVector;
 use std::fs;
 use std::env;
@@ -11,7 +11,7 @@ fn main() -> anyhow::Result<()> {
     }
     let data = fs::read_to_string(&args[1])?;
     let nv = NutritionVector::from_fdc_json(&data)?;
-    let scores = evaluate_all_scores(&nv);
-    println!("{}", serde_json::to_string_pretty(&scores)?);
+    let json = print_scores_as_json(&nv);
+    println!("{}", json);
     Ok(())
 }

--- a/rust/src/scores/mod.rs
+++ b/rust/src/scores/mod.rs
@@ -1,3 +1,5 @@
+//! Available scores: AHEI, HEI, DASH, DASHI, aMED, DII, ACS2020, PHDI, MIND
+
 use crate::nutrition_vector::NutritionVector;
 
 pub trait DietScore {
@@ -7,6 +9,10 @@ pub trait DietScore {
 
 pub fn capped_score(value: f64, max: f64) -> f64 {
     (value / max * 10.0).clamp(0.0, 10.0)
+}
+
+pub fn format_score_name<T: DietScore>(scorer: &T) -> String {
+    scorer.name().to_string()
 }
 
 pub mod ahei;

--- a/rust/tests/score_tests.rs
+++ b/rust/tests/score_tests.rs
@@ -10,6 +10,10 @@ use dietarycodex::scores::acs2020::Acs2020Scorer;
 use dietarycodex::scores::mind::MindScorer;
 use dietarycodex::scores::phdi::PhdiScorer;
 
+const EXPECTED_NAMES: &[&str] = &[
+    "AHEI", "HEI", "DASH", "DASHI", "aMED", "DII", "PHDI", "ACS2020", "MIND",
+];
+
 #[test]
 fn hei_score_not_nan() {
     let nv = NutritionVector {
@@ -83,14 +87,14 @@ fn evaluate_returns_dash() {
         ..Default::default()
     };
     let scores = evaluate_all_scores(&nv);
-    assert!(scores.contains_key("DASH"));
+    assert!(scores.scores.contains_key("DASH"));
 }
 
 #[test]
 fn evaluate_returns_dashi() {
     let nv = NutritionVector::default();
     let scores = evaluate_all_scores(&nv);
-    assert!(scores.contains_key("DASHI"));
+    assert!(scores.scores.contains_key("DASHI"));
 }
 
 #[test]
@@ -110,7 +114,7 @@ fn evaluate_returns_dii() {
         ..Default::default()
     };
     let scores = evaluate_all_scores(&nv);
-    assert!(scores.contains_key("DII"));
+    assert!(scores.scores.contains_key("DII"));
     let scorer = DiiScorer;
     let val = scorer.score(&nv);
     assert!(!val.is_nan());
@@ -137,7 +141,7 @@ fn acs2020_score_not_nan() {
 fn evaluate_returns_acs2020() {
     let nv = NutritionVector::default();
     let scores = evaluate_all_scores(&nv);
-    assert!(scores.contains_key("ACS2020"));
+    assert!(scores.scores.contains_key("ACS2020"));
 }
 
 #[test]
@@ -164,7 +168,7 @@ fn phdi_score_not_nan() {
 fn evaluate_returns_phdi() {
     let nv = NutritionVector::default();
     let scores = evaluate_all_scores(&nv);
-    assert!(scores.contains_key("PHDI"));
+    assert!(scores.scores.contains_key("PHDI"));
 }
 
 #[test]
@@ -193,5 +197,15 @@ fn mind_score_not_nan() {
 fn evaluate_returns_mind() {
     let nv = NutritionVector::default();
     let scores = evaluate_all_scores(&nv);
-    assert!(scores.contains_key("MIND"));
+    assert!(scores.scores.contains_key("MIND"));
+}
+
+#[test]
+fn default_evaluates_all_scores() {
+    let nv = NutritionVector::default();
+    let result = evaluate_all_scores(&nv);
+    for name in EXPECTED_NAMES {
+        assert!(result.scores.contains_key(*name), "missing {name}");
+    }
+    assert_eq!(result.ordered_names, EXPECTED_NAMES.iter().map(|s| s.to_string()).collect::<Vec<_>>());
 }


### PR DESCRIPTION
## Summary
- use a new `ScoreResult` struct for aggregated scores
- document all available scores
- add helper `format_score_name`
- expose pretty JSON output via `print_scores_as_json`
- revise CLI and tests for the updated API

## Testing
- `cargo test --quiet`
- `pre-commit run --files rust/src/eval.rs rust/src/scores/mod.rs rust/src/main.rs rust/tests/score_tests.rs`

------
https://chatgpt.com/codex/tasks/task_b_6861450448d08333bfb53782e24fcc69