### PR TITLE
Refactor scorer trait naming

### DIFF
--- a/rust/src/eval.rs
+++ b/rust/src/eval.rs
@@ -15,7 +15,7 @@ pub fn evaluate_all_scores(nv: &NutritionVector) -> ScoreResult {
     let mut ordered = Vec::new();
     for calc in calculators {
         let name = calc.name().to_string();
-        let val = calc.score(nv);
+        let val = calc.evaluate(nv);
         ordered.push(name.clone());
         results.insert(name, val);
     }

--- a/rust/src/scores/acs2020.rs
+++ b/rust/src/scores/acs2020.rs
@@ -4,7 +4,7 @@ use crate::nutrition_vector::NutritionVector;
 pub struct Acs2020Scorer;
 
 impl DietScore for Acs2020Scorer {
-    fn score(&self, nv: &NutritionVector) -> f64 {
+    fn evaluate(&self, nv: &NutritionVector) -> f64 {
         let veg = capped_score(nv.vegetables_g, 300.0);
         let fruit = capped_score(nv.total_fruits_g, 200.0);
         let legumes = capped_score(nv.legumes_g, 100.0);

--- a/rust/src/scores/ahei.rs
+++ b/rust/src/scores/ahei.rs
@@ -4,7 +4,7 @@ use super::DietScore;
 pub struct Ahei;
 
 impl DietScore for Ahei {
-    fn score(&self, nv: &NutritionVector) -> f64 {
+    fn evaluate(&self, nv: &NutritionVector) -> f64 {
         // Simplified scoring: ratio of healthy components
         let mut score = 0.0;
         if nv.fiber_g >= 25.0 {

--- a/rust/src/scores/amed.rs
+++ b/rust/src/scores/amed.rs
@@ -4,7 +4,7 @@ use crate::nutrition_vector::NutritionVector;
 pub struct AMedScorer;
 
 impl DietScore for AMedScorer {
-    fn score(&self, nv: &NutritionVector) -> f64 {
+    fn evaluate(&self, nv: &NutritionVector) -> f64 {
         let veg = capped_score(nv.vegetables_g, 300.0);
         let legumes = capped_score(nv.legumes_g, 100.0);
         let fruit = capped_score(nv.total_fruits_g, 200.0);

--- a/rust/src/scores/dash.rs
+++ b/rust/src/scores/dash.rs
@@ -4,7 +4,7 @@ use crate::nutrition_vector::NutritionVector;
 pub struct DashScorer;
 
 impl DietScore for DashScorer {
-    fn score(&self, nv: &NutritionVector) -> f64 {
+    fn evaluate(&self, nv: &NutritionVector) -> f64 {
         let fruit = (nv.total_fruits_g / 400.0 * 10.0).clamp(0.0, 10.0);
         let veg = (nv.vegetables_g / 400.0 * 10.0).clamp(0.0, 10.0);
         let grains = (nv.whole_grains_g / 75.0 * 10.0).clamp(0.0, 10.0);

--- a/rust/src/scores/dashi.rs
+++ b/rust/src/scores/dashi.rs
@@ -4,7 +4,7 @@ use crate::nutrition_vector::NutritionVector;
 pub struct DashiScorer;
 
 impl DietScore for DashiScorer {
-    fn score(&self, nv: &NutritionVector) -> f64 {
+    fn evaluate(&self, nv: &NutritionVector) -> f64 {
         let veg = capped_score(nv.vegetables_g, 400.0) / 5.0;
         let fruit = capped_score(nv.total_fruits_g, 400.0) / 5.0;
         let dairy = capped_score(nv.calcium_mg, 1000.0) / 5.0;

--- a/rust/src/scores/dii.rs
+++ b/rust/src/scores/dii.rs
@@ -4,7 +4,7 @@ use crate::nutrition_vector::NutritionVector;
 pub struct DiiScorer;
 
 impl DietScore for DiiScorer {
-    fn score(&self, nv: &NutritionVector) -> f64 {
+    fn evaluate(&self, nv: &NutritionVector) -> f64 {
         // Placeholder weighted scoring reflecting inflammatory potential.
         let mut score = 0.0;
         // pro-inflammatory components

--- a/rust/src/scores/hei.rs
+++ b/rust/src/scores/hei.rs
@@ -4,7 +4,7 @@ use crate::nutrition_vector::NutritionVector;
 pub struct HeiScorer;
 
 impl DietScore for HeiScorer {
-    fn score(&self, nv: &NutritionVector) -> f64 {
+    fn evaluate(&self, nv: &NutritionVector) -> f64 {
         let mut score = 0.0;
         // fruit component: 0-10 points with 200g threshold
         score += (nv.total_fruits_g / 200.0 * 10.0).clamp(0.0, 10.0);

--- a/rust/src/scores/mind.rs
+++ b/rust/src/scores/mind.rs
@@ -4,7 +4,7 @@ use crate::nutrition_vector::NutritionVector;
 pub struct MindScorer;
 
 impl DietScore for MindScorer {
-    fn score(&self, nv: &NutritionVector) -> f64 {
+    fn evaluate(&self, nv: &NutritionVector) -> f64 {
         let leafy = capped_score(nv.vegetables_g, 100.0) / 10.0;
         let berries = capped_score(nv.berries_g, 50.0) / 10.0;
         let nuts = capped_score(nv.nuts_g, 30.0) / 10.0;

--- a/rust/src/scores/mod.rs
+++ b/rust/src/scores/mod.rs
@@ -3,17 +3,14 @@
 use crate::nutrition_vector::NutritionVector;
 
 pub trait DietScore {
-    fn score(&self, nv: &NutritionVector) -> f64;
     fn name(&self) -> &'static str;
+    fn evaluate(&self, nv: &NutritionVector) -> f64;
 }
 
 pub fn capped_score(value: f64, max: f64) -> f64 {
     (value / max * 10.0).clamp(0.0, 10.0)
 }
 
-pub fn format_score_name<T: DietScore>(scorer: &T) -> String {
-    scorer.name().to_string()
-}
 
 pub mod ahei;
 pub mod amed;

--- a/rust/src/scores/phdi.rs
+++ b/rust/src/scores/phdi.rs
@@ -4,7 +4,7 @@ use crate::nutrition_vector::NutritionVector;
 pub struct PhdiScorer;
 
 impl DietScore for PhdiScorer {
-    fn score(&self, nv: &NutritionVector) -> f64 {
+    fn evaluate(&self, nv: &NutritionVector) -> f64 {
         let veg = capped_score(nv.vegetables_g, 300.0);
         let legumes = capped_score(nv.legumes_g, 100.0);
         let grains = capped_score(nv.whole_grains_g, 90.0);

--- a/rust/tests/score_tests.rs
+++ b/rust/tests/score_tests.rs
@@ -23,7 +23,7 @@ fn hei_score_not_nan() {
         ..Default::default()
     };
     let scorer = HeiScorer;
-    let val = scorer.score(&nv);
+    let val = scorer.evaluate(&nv);
     assert!(!val.is_nan());
 }
 
@@ -39,7 +39,7 @@ fn dash_score_not_nan() {
         ..Default::default()
     };
     let scorer = DashScorer;
-    let val = scorer.score(&nv);
+    let val = scorer.evaluate(&nv);
     assert!(!val.is_nan());
 }
 
@@ -54,7 +54,7 @@ fn dashi_score_not_nan() {
         ..Default::default()
     };
     let scorer = DashiScorer;
-    let val = scorer.score(&nv);
+    let val = scorer.evaluate(&nv);
     assert!(!val.is_nan());
 }
 
@@ -71,7 +71,7 @@ fn amed_score_not_nan() {
         ..Default::default()
     };
     let scorer = AMedScorer;
-    let val = scorer.score(&nv);
+    let val = scorer.evaluate(&nv);
     assert!(!val.is_nan());
 }
 
@@ -116,7 +116,7 @@ fn evaluate_returns_dii() {
     let scores = evaluate_all_scores(&nv);
     assert!(scores.scores.contains_key("DII"));
     let scorer = DiiScorer;
-    let val = scorer.score(&nv);
+    let val = scorer.evaluate(&nv);
     assert!(!val.is_nan());
 }
 
@@ -133,7 +133,7 @@ fn acs2020_score_not_nan() {
         ..Default::default()
     };
     let scorer = Acs2020Scorer;
-    let val = scorer.score(&nv);
+    let val = scorer.evaluate(&nv);
     assert!(!val.is_nan());
 }
 
@@ -160,7 +160,7 @@ fn phdi_score_not_nan() {
         ..Default::default()
     };
     let scorer = PhdiScorer;
-    let val = scorer.score(&nv);
+    let val = scorer.evaluate(&nv);
     assert!(!val.is_nan());
 }
 
@@ -189,7 +189,7 @@ fn mind_score_not_nan() {
         ..Default::default()
     };
     let scorer = MindScorer;
-    let val = scorer.score(&nv);
+    let val = scorer.evaluate(&nv);
     assert!(!val.is_nan());
 }
 


### PR DESCRIPTION
## Summary
- refactor `DietScore` trait to require `name()` and `evaluate()`
- implement new trait on all scorers
- update evaluation logic and tests
- drop unused name-formatting helper

## Testing
- `cargo test --manifest-path rust/Cargo.toml`
- `pre-commit run --all-files` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_686146b1c55c8333a4fc8086e5a79e85