### PR TITLE
Simplify scorer registration with macro

### DIFF
--- a/rust/src/scores/mod.rs
+++ b/rust/src/scores/mod.rs
@@ -1,4 +1,4 @@
-//! Available scores: AHEI, HEI, DASH, DASHI, aMED, DII, ACS2020, PHDI, MIND
+//! Available scorers: AHEI, HEI, DASH, aMED, DII, ACS2020, PHDI, DASHI, MIND
 
 use crate::nutrition_vector::NutritionVector;
 
@@ -23,4 +23,5 @@ pub mod phdi;
 pub mod mind;
 pub mod registry;
 
+/// Available scorers: AHEI, HEI, DASH, aMED, DII, ACS2020, PHDI, DASHI, MIND
 pub use registry::all_scorers;

--- a/rust/src/scores/registry.rs
+++ b/rust/src/scores/registry.rs
@@ -1,19 +1,23 @@
-use super::{
-    acs2020::Acs2020Scorer, ahei::Ahei, amed::AMedScorer, dash::DashScorer,
-    dashi::DashiScorer, dii::DiiScorer, hei::HeiScorer, mind::MindScorer,
-    phdi::PhdiScorer, DietScore,
-};
+use super::DietScore;
+
+#[macro_export]
+macro_rules! register_scores {
+    () => {{
+        let scores: Vec<Box<dyn $crate::scores::DietScore>> = vec![
+            Box::new($crate::scores::ahei::Ahei),
+            Box::new($crate::scores::hei::HeiScorer),
+            Box::new($crate::scores::dash::DashScorer),
+            Box::new($crate::scores::dashi::DashiScorer),
+            Box::new($crate::scores::amed::AMedScorer),
+            Box::new($crate::scores::dii::DiiScorer),
+            Box::new($crate::scores::phdi::PhdiScorer),
+            Box::new($crate::scores::acs2020::Acs2020Scorer),
+            Box::new($crate::scores::mind::MindScorer),
+        ];
+        scores
+    }};
+}
 
 pub fn all_scorers() -> Vec<Box<dyn DietScore>> {
-    vec![
-        Box::new(Ahei),
-        Box::new(HeiScorer),
-        Box::new(DashScorer),
-        Box::new(DashiScorer),
-        Box::new(AMedScorer),
-        Box::new(DiiScorer),
-        Box::new(PhdiScorer),
-        Box::new(Acs2020Scorer),
-        Box::new(MindScorer),
-    ]
+    register_scores!()
 }

--- a/rust/tests/score_tests.rs
+++ b/rust/tests/score_tests.rs
@@ -10,9 +10,12 @@ use dietarycodex::scores::acs2020::Acs2020Scorer;
 use dietarycodex::scores::mind::MindScorer;
 use dietarycodex::scores::phdi::PhdiScorer;
 
-const EXPECTED_NAMES: &[&str] = &[
-    "AHEI", "HEI", "DASH", "DASHI", "aMED", "DII", "PHDI", "ACS2020", "MIND",
-];
+fn expected_names() -> Vec<String> {
+    dietarycodex::register_scores!()
+        .into_iter()
+        .map(|s| s.name().to_string())
+        .collect()
+}
 
 #[test]
 fn hei_score_not_nan() {
@@ -204,8 +207,9 @@ fn evaluate_returns_mind() {
 fn default_evaluates_all_scores() {
     let nv = NutritionVector::default();
     let result = evaluate_all_scores(&nv);
-    for name in EXPECTED_NAMES {
-        assert!(result.scores.contains_key(*name), "missing {name}");
+    let expected = expected_names();
+    for name in &expected {
+        assert!(result.scores.contains_key(name.as_str()), "missing {name}");
     }
-    assert_eq!(result.ordered_names, EXPECTED_NAMES.iter().map(|s| s.to_string()).collect::<Vec<_>>());
+    assert_eq!(result.ordered_names, expected);
 }


### PR DESCRIPTION
## Summary
- add `register_scores!` macro for building the scorer list
- use the macro inside the registry and tests
- document available scorers in `scores::mod`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_b_6861488400e08333b84aac8db5173940