### PR TITLE
Add score metadata registry and CLI listing

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,25 +1,36 @@
 use dietarycodex::eval::{print_scores_as_json, print_scores_as_json_allow_partial};
 use dietarycodex::nutrition_vector::NutritionVector;
-use std::fs;
+use dietarycodex::scores::registry::all_score_metadata;
+use serde_json::to_string_pretty;
 use std::env;
+use std::fs;
 
 fn main() -> anyhow::Result<()> {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
-        eprintln!("Usage: {} <fdc_json> [--allow-partial]", args[0]);
+        eprintln!("Usage: {} <fdc_json> [--allow-partial] [--list-scores]", args[0]);
         std::process::exit(1);
     }
     let mut allow_partial = false;
     let mut file = String::new();
+    let mut list_scores = false;
     for arg in args.iter().skip(1) {
         if arg == "--allow-partial" {
             allow_partial = true;
+        } else if arg == "--list-scores" {
+            list_scores = true;
         } else {
             file = arg.clone();
         }
     }
+    if list_scores {
+        let meta = all_score_metadata();
+        let json = to_string_pretty(&meta)?;
+        println!("{}", json);
+        return Ok(());
+    }
     if file.is_empty() {
-        eprintln!("Usage: {} <fdc_json> [--allow-partial]", args[0]);
+        eprintln!("Usage: {} <fdc_json> [--allow-partial] [--list-scores]", args[0]);
         std::process::exit(1);
     }
     let data = fs::read_to_string(&file)?;

--- a/rust/src/nutrition_vector.rs
+++ b/rust/src/nutrition_vector.rs
@@ -40,6 +40,42 @@ pub struct NutritionVector {
     pub alcohol_g: Option<f64>,
 }
 
+static ALL_FIELD_NAMES: &[&str] = &[
+    "energy_kcal",
+    "fat_g",
+    "saturated_fat_g",
+    "carbs_g",
+    "fiber_g",
+    "sugar_g",
+    "protein_g",
+    "sodium_mg",
+    "calcium_mg",
+    "iron_mg",
+    "vitamin_c_mg",
+    "total_fruits_g",
+    "vegetables_g",
+    "whole_grains_g",
+    "refined_grains_g",
+    "legumes_g",
+    "fish_g",
+    "red_meat_g",
+    "mono_fat_g",
+    "berries_g",
+    "cheese_g",
+    "butter_g",
+    "poultry_g",
+    "fast_food_g",
+    "nuts_g",
+    "omega3_g",
+    "vitamin_a_mcg",
+    "vitamin_e_mg",
+    "zinc_mg",
+    "selenium_mcg",
+    "magnesium_mg",
+    "trans_fat_g",
+    "alcohol_g",
+];
+
 impl NutritionVector {
     pub fn from_fdc_json(data: &str) -> anyhow::Result<Self> {
         let v: Value = serde_json::from_str(data)?;
@@ -188,5 +224,9 @@ impl NutritionVector {
             missing.push("alcohol_g");
         }
         missing
+    }
+
+    pub fn all_field_names() -> &'static [&'static str] {
+        ALL_FIELD_NAMES
     }
 }

--- a/rust/src/scores/acs2020.rs
+++ b/rust/src/scores/acs2020.rs
@@ -1,7 +1,25 @@
-use super::{capped_score, DietScore};
+use super::{capped_score, DietScore, FieldDeps};
 use crate::nutrition_vector::NutritionVector;
 
 pub struct Acs2020Scorer;
+
+impl FieldDeps for Acs2020Scorer {
+    fn name() -> &'static str {
+        "ACS2020"
+    }
+
+    fn required_fields() -> &'static [&'static str] {
+        &[
+            "vegetables_g",
+            "total_fruits_g",
+            "legumes_g",
+            "whole_grains_g",
+            "red_meat_g",
+            "sugar_g",
+            "alcohol_g",
+        ]
+    }
+}
 
 impl DietScore for Acs2020Scorer {
     fn evaluate(&self, nv: &NutritionVector) -> f64 {
@@ -16,18 +34,10 @@ impl DietScore for Acs2020Scorer {
     }
 
     fn name(&self) -> &'static str {
-        "ACS2020"
+        <Self as FieldDeps>::name()
     }
 
     fn required_fields(&self) -> &'static [&'static str] {
-        &[
-            "vegetables_g",
-            "total_fruits_g",
-            "legumes_g",
-            "whole_grains_g",
-            "red_meat_g",
-            "sugar_g",
-            "alcohol_g",
-        ]
+        <Self as FieldDeps>::required_fields()
     }
 }

--- a/rust/src/scores/ahei.rs
+++ b/rust/src/scores/ahei.rs
@@ -1,7 +1,17 @@
 use crate::nutrition_vector::NutritionVector;
-use super::DietScore;
+use super::{DietScore, FieldDeps};
 
 pub struct Ahei;
+
+impl FieldDeps for Ahei {
+    fn name() -> &'static str {
+        "AHEI"
+    }
+
+    fn required_fields() -> &'static [&'static str] {
+        &["fiber_g", "fat_g", "saturated_fat_g"]
+    }
+}
 
 impl DietScore for Ahei {
     fn evaluate(&self, nv: &NutritionVector) -> f64 {
@@ -21,10 +31,10 @@ impl DietScore for Ahei {
     }
 
     fn name(&self) -> &'static str {
-        "AHEI"
+        <Self as FieldDeps>::name()
     }
 
     fn required_fields(&self) -> &'static [&'static str] {
-        &["fiber_g", "fat_g", "saturated_fat_g"]
+        <Self as FieldDeps>::required_fields()
     }
 }

--- a/rust/src/scores/amed.rs
+++ b/rust/src/scores/amed.rs
@@ -1,7 +1,25 @@
-use super::{capped_score, DietScore};
+use super::{capped_score, DietScore, FieldDeps};
 use crate::nutrition_vector::NutritionVector;
 
 pub struct AMedScorer;
+
+impl FieldDeps for AMedScorer {
+    fn name() -> &'static str {
+        "aMED"
+    }
+
+    fn required_fields() -> &'static [&'static str] {
+        &[
+            "vegetables_g",
+            "legumes_g",
+            "total_fruits_g",
+            "whole_grains_g",
+            "fish_g",
+            "mono_fat_g",
+            "red_meat_g",
+        ]
+    }
+}
 
 impl DietScore for AMedScorer {
     fn evaluate(&self, nv: &NutritionVector) -> f64 {
@@ -17,18 +35,10 @@ impl DietScore for AMedScorer {
     }
 
     fn name(&self) -> &'static str {
-        "aMED"
+        <Self as FieldDeps>::name()
     }
 
     fn required_fields(&self) -> &'static [&'static str] {
-        &[
-            "vegetables_g",
-            "legumes_g",
-            "total_fruits_g",
-            "whole_grains_g",
-            "fish_g",
-            "mono_fat_g",
-            "red_meat_g",
-        ]
+        <Self as FieldDeps>::required_fields()
     }
 }

--- a/rust/src/scores/dash.rs
+++ b/rust/src/scores/dash.rs
@@ -1,7 +1,24 @@
-use super::DietScore;
+use super::{DietScore, FieldDeps};
 use crate::nutrition_vector::NutritionVector;
 
 pub struct DashScorer;
+
+impl FieldDeps for DashScorer {
+    fn name() -> &'static str {
+        "DASH"
+    }
+
+    fn required_fields() -> &'static [&'static str] {
+        &[
+            "total_fruits_g",
+            "vegetables_g",
+            "whole_grains_g",
+            "sodium_mg",
+            "saturated_fat_g",
+            "energy_kcal",
+        ]
+    }
+}
 
 impl DietScore for DashScorer {
     fn evaluate(&self, nv: &NutritionVector) -> f64 {
@@ -31,17 +48,10 @@ impl DietScore for DashScorer {
     }
 
     fn name(&self) -> &'static str {
-        "DASH"
+        <Self as FieldDeps>::name()
     }
 
     fn required_fields(&self) -> &'static [&'static str] {
-        &[
-            "total_fruits_g",
-            "vegetables_g",
-            "whole_grains_g",
-            "sodium_mg",
-            "saturated_fat_g",
-            "energy_kcal",
-        ]
+        <Self as FieldDeps>::required_fields()
     }
 }

--- a/rust/src/scores/dashi.rs
+++ b/rust/src/scores/dashi.rs
@@ -1,7 +1,23 @@
-use super::{capped_score, DietScore};
+use super::{capped_score, DietScore, FieldDeps};
 use crate::nutrition_vector::NutritionVector;
 
 pub struct DashiScorer;
+
+impl FieldDeps for DashiScorer {
+    fn name() -> &'static str {
+        "DASHI"
+    }
+
+    fn required_fields() -> &'static [&'static str] {
+        &[
+            "vegetables_g",
+            "total_fruits_g",
+            "calcium_mg",
+            "whole_grains_g",
+            "sodium_mg",
+        ]
+    }
+}
 
 impl DietScore for DashiScorer {
     fn evaluate(&self, nv: &NutritionVector) -> f64 {
@@ -20,16 +36,10 @@ impl DietScore for DashiScorer {
     }
 
     fn name(&self) -> &'static str {
-        "DASHI"
+        <Self as FieldDeps>::name()
     }
 
     fn required_fields(&self) -> &'static [&'static str] {
-        &[
-            "vegetables_g",
-            "total_fruits_g",
-            "calcium_mg",
-            "whole_grains_g",
-            "sodium_mg",
-        ]
+        <Self as FieldDeps>::required_fields()
     }
 }

--- a/rust/src/scores/dii.rs
+++ b/rust/src/scores/dii.rs
@@ -1,7 +1,29 @@
-use super::DietScore;
+use super::{DietScore, FieldDeps};
 use crate::nutrition_vector::NutritionVector;
 
 pub struct DiiScorer;
+
+impl FieldDeps for DiiScorer {
+    fn name() -> &'static str {
+        "DII"
+    }
+
+    fn required_fields() -> &'static [&'static str] {
+        &[
+            "saturated_fat_g",
+            "trans_fat_g",
+            "sugar_g",
+            "fiber_g",
+            "vitamin_c_mg",
+            "vitamin_a_mcg",
+            "vitamin_e_mg",
+            "omega3_g",
+            "zinc_mg",
+            "selenium_mcg",
+            "magnesium_mg",
+        ]
+    }
+}
 
 impl DietScore for DiiScorer {
     fn evaluate(&self, nv: &NutritionVector) -> f64 {
@@ -24,22 +46,10 @@ impl DietScore for DiiScorer {
     }
 
     fn name(&self) -> &'static str {
-        "DII"
+        <Self as FieldDeps>::name()
     }
 
     fn required_fields(&self) -> &'static [&'static str] {
-        &[
-            "saturated_fat_g",
-            "trans_fat_g",
-            "sugar_g",
-            "fiber_g",
-            "vitamin_c_mg",
-            "vitamin_a_mcg",
-            "vitamin_e_mg",
-            "omega3_g",
-            "zinc_mg",
-            "selenium_mcg",
-            "magnesium_mg",
-        ]
+        <Self as FieldDeps>::required_fields()
     }
 }

--- a/rust/src/scores/hei.rs
+++ b/rust/src/scores/hei.rs
@@ -1,7 +1,17 @@
-use super::DietScore;
+use super::{DietScore, FieldDeps};
 use crate::nutrition_vector::NutritionVector;
 
 pub struct HeiScorer;
+
+impl FieldDeps for HeiScorer {
+    fn name() -> &'static str {
+        "HEI"
+    }
+
+    fn required_fields() -> &'static [&'static str] {
+        &["total_fruits_g", "whole_grains_g", "sodium_mg"]
+    }
+}
 
 impl DietScore for HeiScorer {
     fn evaluate(&self, nv: &NutritionVector) -> f64 {
@@ -22,10 +32,10 @@ impl DietScore for HeiScorer {
     }
 
     fn name(&self) -> &'static str {
-        "HEI"
+        <Self as FieldDeps>::name()
     }
 
     fn required_fields(&self) -> &'static [&'static str] {
-        &["total_fruits_g", "whole_grains_g", "sodium_mg"]
+        <Self as FieldDeps>::required_fields()
     }
 }

--- a/rust/src/scores/mind.rs
+++ b/rust/src/scores/mind.rs
@@ -1,7 +1,30 @@
-use super::{capped_score, DietScore};
+use super::{capped_score, DietScore, FieldDeps};
 use crate::nutrition_vector::NutritionVector;
 
 pub struct MindScorer;
+
+impl FieldDeps for MindScorer {
+    fn name() -> &'static str {
+        "MIND"
+    }
+
+    fn required_fields() -> &'static [&'static str] {
+        &[
+            "vegetables_g",
+            "berries_g",
+            "nuts_g",
+            "whole_grains_g",
+            "fish_g",
+            "poultry_g",
+            "mono_fat_g",
+            "red_meat_g",
+            "fast_food_g",
+            "sugar_g",
+            "cheese_g",
+            "butter_g",
+        ]
+    }
+}
 
 impl DietScore for MindScorer {
     fn evaluate(&self, nv: &NutritionVector) -> f64 {
@@ -34,23 +57,10 @@ impl DietScore for MindScorer {
     }
 
     fn name(&self) -> &'static str {
-        "MIND"
+        <Self as FieldDeps>::name()
     }
 
     fn required_fields(&self) -> &'static [&'static str] {
-        &[
-            "vegetables_g",
-            "berries_g",
-            "nuts_g",
-            "whole_grains_g",
-            "fish_g",
-            "poultry_g",
-            "mono_fat_g",
-            "red_meat_g",
-            "fast_food_g",
-            "sugar_g",
-            "cheese_g",
-            "butter_g",
-        ]
+        <Self as FieldDeps>::required_fields()
     }
 }

--- a/rust/src/scores/mod.rs
+++ b/rust/src/scores/mod.rs
@@ -2,6 +2,11 @@
 
 use crate::nutrition_vector::NutritionVector;
 
+pub trait FieldDeps {
+    fn name() -> &'static str;
+    fn required_fields() -> &'static [&'static str];
+}
+
 pub trait DietScore {
     fn name(&self) -> &'static str;
     fn evaluate(&self, nv: &NutritionVector) -> f64;

--- a/rust/src/scores/phdi.rs
+++ b/rust/src/scores/phdi.rs
@@ -1,7 +1,28 @@
-use super::{capped_score, DietScore};
+use super::{capped_score, DietScore, FieldDeps};
 use crate::nutrition_vector::NutritionVector;
 
 pub struct PhdiScorer;
+
+impl FieldDeps for PhdiScorer {
+    fn name() -> &'static str {
+        "PHDI"
+    }
+
+    fn required_fields() -> &'static [&'static str] {
+        &[
+            "vegetables_g",
+            "legumes_g",
+            "whole_grains_g",
+            "fat_g",
+            "saturated_fat_g",
+            "trans_fat_g",
+            "red_meat_g",
+            "sugar_g",
+            "refined_grains_g",
+            "energy_kcal",
+        ]
+    }
+}
 
 impl DietScore for PhdiScorer {
     fn evaluate(&self, nv: &NutritionVector) -> f64 {
@@ -27,21 +48,10 @@ impl DietScore for PhdiScorer {
     }
 
     fn name(&self) -> &'static str {
-        "PHDI"
+        <Self as FieldDeps>::name()
     }
 
     fn required_fields(&self) -> &'static [&'static str] {
-        &[
-            "vegetables_g",
-            "legumes_g",
-            "whole_grains_g",
-            "fat_g",
-            "saturated_fat_g",
-            "trans_fat_g",
-            "red_meat_g",
-            "sugar_g",
-            "refined_grains_g",
-            "energy_kcal",
-        ]
+        <Self as FieldDeps>::required_fields()
     }
 }

--- a/rust/src/scores/registry.rs
+++ b/rust/src/scores/registry.rs
@@ -1,4 +1,5 @@
-use super::DietScore;
+use super::{DietScore, FieldDeps};
+use serde::Serialize;
 
 #[macro_export]
 macro_rules! register_scores {
@@ -20,4 +21,51 @@ macro_rules! register_scores {
 
 pub fn all_scorers() -> Vec<Box<dyn DietScore>> {
     register_scores!()
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct ScoreMeta {
+    pub name: &'static str,
+    pub required_fields: &'static [&'static str],
+}
+
+pub fn all_score_metadata() -> Vec<ScoreMeta> {
+    vec![
+        ScoreMeta {
+            name: <crate::scores::ahei::Ahei as FieldDeps>::name(),
+            required_fields: <crate::scores::ahei::Ahei as FieldDeps>::required_fields(),
+        },
+        ScoreMeta {
+            name: <crate::scores::hei::HeiScorer as FieldDeps>::name(),
+            required_fields: <crate::scores::hei::HeiScorer as FieldDeps>::required_fields(),
+        },
+        ScoreMeta {
+            name: <crate::scores::dash::DashScorer as FieldDeps>::name(),
+            required_fields: <crate::scores::dash::DashScorer as FieldDeps>::required_fields(),
+        },
+        ScoreMeta {
+            name: <crate::scores::dashi::DashiScorer as FieldDeps>::name(),
+            required_fields: <crate::scores::dashi::DashiScorer as FieldDeps>::required_fields(),
+        },
+        ScoreMeta {
+            name: <crate::scores::amed::AMedScorer as FieldDeps>::name(),
+            required_fields: <crate::scores::amed::AMedScorer as FieldDeps>::required_fields(),
+        },
+        ScoreMeta {
+            name: <crate::scores::dii::DiiScorer as FieldDeps>::name(),
+            required_fields: <crate::scores::dii::DiiScorer as FieldDeps>::required_fields(),
+        },
+        ScoreMeta {
+            name: <crate::scores::phdi::PhdiScorer as FieldDeps>::name(),
+            required_fields: <crate::scores::phdi::PhdiScorer as FieldDeps>::required_fields(),
+        },
+        ScoreMeta {
+            name: <crate::scores::acs2020::Acs2020Scorer as FieldDeps>::name(),
+            required_fields: <crate::scores::acs2020::Acs2020Scorer as FieldDeps>::required_fields(),
+        },
+        ScoreMeta {
+            name: <crate::scores::mind::MindScorer as FieldDeps>::name(),
+            required_fields: <crate::scores::mind::MindScorer as FieldDeps>::required_fields(),
+        },
+    ]
 }

--- a/rust/tests/score_tests.rs
+++ b/rust/tests/score_tests.rs
@@ -228,3 +228,16 @@ fn allow_partial_skips_missing() {
     assert!(result.scores.contains_key("AHEI"));
     assert!(!result.scores.contains_key("DASH"));
 }
+
+#[test]
+fn metadata_fields_are_valid() {
+    use dietarycodex::scores::registry::all_score_metadata;
+    use std::collections::HashSet;
+
+    let all_fields: HashSet<&str> = NutritionVector::all_field_names().iter().copied().collect();
+    for meta in all_score_metadata() {
+        for field in meta.required_fields {
+            assert!(all_fields.contains(field), "{} missing field {}", meta.name, field);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `ScoreMeta` struct for score names and their required fields
- implement `all_score_metadata` for static introspection
- expose metadata via `--list-scores` CLI flag
- list all nutrition field names for validation
- add test ensuring score metadata fields are valid

## Testing
- `cargo test --manifest-path rust/Cargo.toml`
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_b_686153773e9c83338a42bfd7acadc75d