### PR TITLE
Improve dietary score metadata

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
  "anyhow",
  "serde",
  "serde_json",
+ "tabwriter",
 ]
 
 [[package]]
@@ -97,7 +98,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabwriter"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fce91f2f0ec87dff7e6bcbbeb267439aa1188703003c6055193c821487400432"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 anyhow = "1"
+tabwriter = "1"

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -2,35 +2,51 @@ use dietarycodex::eval::{print_scores_as_json, print_scores_as_json_allow_partia
 use dietarycodex::nutrition_vector::NutritionVector;
 use dietarycodex::scores::registry::all_score_metadata;
 use serde_json::to_string_pretty;
+use std::io::Write;
+use tabwriter::TabWriter;
 use std::env;
 use std::fs;
 
 fn main() -> anyhow::Result<()> {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
-        eprintln!("Usage: {} <fdc_json> [--allow-partial] [--list-scores]", args[0]);
+        eprintln!("Usage: {} <fdc_json> [--allow-partial] [--list-scores] [--json]", args[0]);
         std::process::exit(1);
     }
     let mut allow_partial = false;
     let mut file = String::new();
     let mut list_scores = false;
+    let mut json_output = false;
     for arg in args.iter().skip(1) {
         if arg == "--allow-partial" {
             allow_partial = true;
         } else if arg == "--list-scores" {
             list_scores = true;
+        } else if arg == "--json" {
+            json_output = true;
         } else {
             file = arg.clone();
         }
     }
     if list_scores {
         let meta = all_score_metadata();
-        let json = to_string_pretty(&meta)?;
-        println!("{}", json);
+        if json_output {
+            let json = to_string_pretty(&meta)?;
+            println!("{}", json);
+        } else {
+            let mut tw = TabWriter::new(vec![]);
+            writeln!(&mut tw, "NAME\tREQUIRED_FIELDS")?;
+            for m in meta {
+                let fields = m.required_fields.join(", ");
+                writeln!(&mut tw, "{}\t{}", m.name, fields)?;
+            }
+            tw.flush()?;
+            print!("{}", String::from_utf8(tw.into_inner()?)?);
+        }
         return Ok(());
     }
     if file.is_empty() {
-        eprintln!("Usage: {} <fdc_json> [--allow-partial] [--list-scores]", args[0]);
+        eprintln!("Usage: {} <fdc_json> [--allow-partial] [--list-scores] [--json]", args[0]);
         std::process::exit(1);
     }
     let data = fs::read_to_string(&file)?;

--- a/rust/src/scores/acs2020.rs
+++ b/rust/src/scores/acs2020.rs
@@ -10,13 +10,13 @@ impl FieldDeps for Acs2020Scorer {
 
     fn required_fields() -> &'static [&'static str] {
         &[
-            "vegetables_g",
-            "total_fruits_g",
+            "alcohol_g",
             "legumes_g",
-            "whole_grains_g",
             "red_meat_g",
             "sugar_g",
-            "alcohol_g",
+            "total_fruits_g",
+            "vegetables_g",
+            "whole_grains_g",
         ]
     }
 }

--- a/rust/src/scores/ahei.rs
+++ b/rust/src/scores/ahei.rs
@@ -9,7 +9,7 @@ impl FieldDeps for Ahei {
     }
 
     fn required_fields() -> &'static [&'static str] {
-        &["fiber_g", "fat_g", "saturated_fat_g"]
+        &["fat_g", "fiber_g", "saturated_fat_g"]
     }
 }
 

--- a/rust/src/scores/amed.rs
+++ b/rust/src/scores/amed.rs
@@ -10,13 +10,13 @@ impl FieldDeps for AMedScorer {
 
     fn required_fields() -> &'static [&'static str] {
         &[
-            "vegetables_g",
-            "legumes_g",
-            "total_fruits_g",
-            "whole_grains_g",
             "fish_g",
+            "legumes_g",
             "mono_fat_g",
             "red_meat_g",
+            "total_fruits_g",
+            "vegetables_g",
+            "whole_grains_g",
         ]
     }
 }

--- a/rust/src/scores/dash.rs
+++ b/rust/src/scores/dash.rs
@@ -10,12 +10,12 @@ impl FieldDeps for DashScorer {
 
     fn required_fields() -> &'static [&'static str] {
         &[
+            "energy_kcal",
+            "saturated_fat_g",
+            "sodium_mg",
             "total_fruits_g",
             "vegetables_g",
             "whole_grains_g",
-            "sodium_mg",
-            "saturated_fat_g",
-            "energy_kcal",
         ]
     }
 }

--- a/rust/src/scores/dashi.rs
+++ b/rust/src/scores/dashi.rs
@@ -10,11 +10,11 @@ impl FieldDeps for DashiScorer {
 
     fn required_fields() -> &'static [&'static str] {
         &[
-            "vegetables_g",
-            "total_fruits_g",
             "calcium_mg",
-            "whole_grains_g",
             "sodium_mg",
+            "total_fruits_g",
+            "vegetables_g",
+            "whole_grains_g",
         ]
     }
 }

--- a/rust/src/scores/dii.rs
+++ b/rust/src/scores/dii.rs
@@ -10,17 +10,17 @@ impl FieldDeps for DiiScorer {
 
     fn required_fields() -> &'static [&'static str] {
         &[
-            "saturated_fat_g",
-            "trans_fat_g",
-            "sugar_g",
             "fiber_g",
-            "vitamin_c_mg",
-            "vitamin_a_mcg",
-            "vitamin_e_mg",
-            "omega3_g",
-            "zinc_mg",
-            "selenium_mcg",
             "magnesium_mg",
+            "omega3_g",
+            "saturated_fat_g",
+            "selenium_mcg",
+            "sugar_g",
+            "trans_fat_g",
+            "vitamin_a_mcg",
+            "vitamin_c_mg",
+            "vitamin_e_mg",
+            "zinc_mg",
         ]
     }
 }

--- a/rust/src/scores/hei.rs
+++ b/rust/src/scores/hei.rs
@@ -9,7 +9,7 @@ impl FieldDeps for HeiScorer {
     }
 
     fn required_fields() -> &'static [&'static str] {
-        &["total_fruits_g", "whole_grains_g", "sodium_mg"]
+        &["sodium_mg", "total_fruits_g", "whole_grains_g"]
     }
 }
 

--- a/rust/src/scores/mind.rs
+++ b/rust/src/scores/mind.rs
@@ -10,18 +10,18 @@ impl FieldDeps for MindScorer {
 
     fn required_fields() -> &'static [&'static str] {
         &[
-            "vegetables_g",
             "berries_g",
-            "nuts_g",
-            "whole_grains_g",
-            "fish_g",
-            "poultry_g",
-            "mono_fat_g",
-            "red_meat_g",
-            "fast_food_g",
-            "sugar_g",
-            "cheese_g",
             "butter_g",
+            "cheese_g",
+            "fast_food_g",
+            "fish_g",
+            "mono_fat_g",
+            "nuts_g",
+            "poultry_g",
+            "red_meat_g",
+            "sugar_g",
+            "vegetables_g",
+            "whole_grains_g",
         ]
     }
 }

--- a/rust/src/scores/phdi.rs
+++ b/rust/src/scores/phdi.rs
@@ -10,16 +10,16 @@ impl FieldDeps for PhdiScorer {
 
     fn required_fields() -> &'static [&'static str] {
         &[
-            "vegetables_g",
-            "legumes_g",
-            "whole_grains_g",
-            "fat_g",
-            "saturated_fat_g",
-            "trans_fat_g",
-            "red_meat_g",
-            "sugar_g",
-            "refined_grains_g",
             "energy_kcal",
+            "fat_g",
+            "legumes_g",
+            "red_meat_g",
+            "refined_grains_g",
+            "saturated_fat_g",
+            "sugar_g",
+            "trans_fat_g",
+            "vegetables_g",
+            "whole_grains_g",
         ]
     }
 }

--- a/rust/src/scores/registry.rs
+++ b/rust/src/scores/registry.rs
@@ -30,7 +30,7 @@ pub struct ScoreMeta {
 }
 
 pub fn all_score_metadata() -> Vec<ScoreMeta> {
-    vec![
+    let mut metas = vec![
         ScoreMeta {
             name: <crate::scores::ahei::Ahei as FieldDeps>::name(),
             required_fields: <crate::scores::ahei::Ahei as FieldDeps>::required_fields(),
@@ -67,5 +67,7 @@ pub fn all_score_metadata() -> Vec<ScoreMeta> {
             name: <crate::scores::mind::MindScorer as FieldDeps>::name(),
             required_fields: <crate::scores::mind::MindScorer as FieldDeps>::required_fields(),
         },
-    ]
+    ];
+    metas.sort_by(|a, b| a.name.cmp(b.name));
+    metas
 }

--- a/rust/tests/score_tests.rs
+++ b/rust/tests/score_tests.rs
@@ -241,3 +241,21 @@ fn metadata_fields_are_valid() {
         }
     }
 }
+
+#[test]
+fn metadata_sorted() {
+    use dietarycodex::scores::registry::all_score_metadata;
+
+    let metas = all_score_metadata();
+    let mut names: Vec<&str> = metas.iter().map(|m| m.name).collect();
+    let mut sorted_names = names.clone();
+    sorted_names.sort();
+    assert_eq!(names, sorted_names, "score metadata not sorted by name");
+
+    for meta in metas {
+        let mut fields: Vec<&str> = meta.required_fields.iter().copied().collect();
+        let mut sorted_fields = fields.clone();
+        sorted_fields.sort();
+        assert_eq!(fields, sorted_fields, "fields for {} not sorted", meta.name);
+    }
+}


### PR DESCRIPTION
## Summary
- alphabetize required fields in each Rust scorer
- print metadata table by default with `--list-scores`
- add optional `--json` flag for raw metadata output
- sort entries returned by `all_score_metadata`
- test alphabetical ordering of metadata

## Testing
- `cargo test`
- `pytest -q`
- `pre-commit run --files rust/src/scores/ahei.rs rust/src/scores/dash.rs rust/src/scores/dashi.rs rust/src/scores/amed.rs rust/src/scores/dii.rs rust/src/scores/acs2020.rs rust/src/scores/phdi.rs rust/src/scores/mind.rs rust/src/scores/hei.rs rust/src/scores/registry.rs rust/src/main.rs rust/tests/score_tests.rs rust/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_b_6861560999048333a793133e6e3777d6