### PR TITLE
Add verbose partial scoring status

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,4 +1,6 @@
-use dietarycodex::eval::{print_scores_as_json, print_scores_as_json_allow_partial};
+use dietarycodex::eval::{
+    evaluate_allow_partial, print_scores_as_json, print_scores_as_json_allow_partial, ScorerStatus,
+};
 use dietarycodex::nutrition_vector::NutritionVector;
 use dietarycodex::scores::registry::all_score_metadata;
 use serde_json::to_string_pretty;
@@ -10,16 +12,19 @@ use std::fs;
 fn main() -> anyhow::Result<()> {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
-        eprintln!("Usage: {} <fdc_json> [--allow-partial] [--list-scores] [--json]", args[0]);
+        eprintln!("Usage: {} <fdc_json> [--allow-partial] [--verbose-partial] [--list-scores] [--json]", args[0]);
         std::process::exit(1);
     }
     let mut allow_partial = false;
+    let mut verbose_partial = false;
     let mut file = String::new();
     let mut list_scores = false;
     let mut json_output = false;
     for arg in args.iter().skip(1) {
         if arg == "--allow-partial" {
             allow_partial = true;
+        } else if arg == "--verbose-partial" {
+            verbose_partial = true;
         } else if arg == "--list-scores" {
             list_scores = true;
         } else if arg == "--json" {
@@ -46,16 +51,28 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
     if file.is_empty() {
-        eprintln!("Usage: {} <fdc_json> [--allow-partial] [--list-scores] [--json]", args[0]);
+        eprintln!("Usage: {} <fdc_json> [--allow-partial] [--verbose-partial] [--list-scores] [--json]", args[0]);
         std::process::exit(1);
     }
     let data = fs::read_to_string(&file)?;
     let nv = NutritionVector::from_fdc_json(&data)?;
-    let json = if allow_partial {
-        print_scores_as_json_allow_partial(&nv)
+    if allow_partial {
+        if verbose_partial {
+            let result = evaluate_allow_partial(&nv);
+            for name in &result.ordered_names {
+                if let Some(ScorerStatus::Skipped { reason }) = result.scores.get(name) {
+                    eprintln!("Skipped {}: {}", name, reason);
+                }
+            }
+            let json = serde_json::to_string_pretty(&result)?;
+            println!("{}", json);
+        } else {
+            let json = print_scores_as_json_allow_partial(&nv);
+            println!("{}", json);
+        }
     } else {
-        print_scores_as_json(&nv)
-    };
-    println!("{}", json);
+        let json = print_scores_as_json(&nv);
+        println!("{}", json);
+    }
     Ok(())
 }

--- a/rust/src/scores/mod.rs
+++ b/rust/src/scores/mod.rs
@@ -1,4 +1,9 @@
-//! Available scorers: AHEI, HEI, DASH, aMED, DII, ACS2020, PHDI, DASHI, MIND
+//! Available scorers: AHEI, HEI, DASH, aMED, DII, ACS2020, PHDI, DASHI, MIND.
+//!
+//! Partial evaluation is supported through [`evaluate_allow_partial`](crate::eval::evaluate_allow_partial).
+//! Each scorer returns a [`ScorerStatus`](crate::eval::ScorerStatus) indicating
+//! whether the score was computed or skipped. Skipped scores include a reason
+//! listing which input fields were missing.
 
 use crate::nutrition_vector::NutritionVector;
 


### PR DESCRIPTION
## Summary
- return per-scorer status with reasons for skipped scores
- add `--verbose-partial` CLI option
- document partial evaluation in scores module
- test skipped reasons for missing fields

## Testing
- `cargo test --quiet`
- `pre-commit run --files rust/src/eval.rs rust/src/main.rs rust/src/scores/mod.rs rust/tests/score_tests.rs`

------
https://chatgpt.com/codex/tasks/task_b_6861583ce8a88333bccbd1804e6c0f0c