### PR TITLE
Improve partial evaluation output

### DIFF
--- a/rust/src/eval.rs
+++ b/rust/src/eval.rs
@@ -15,7 +15,6 @@ pub struct ScoreResult {
     pub ordered_names: Vec<String>,
 }
 
-
 pub fn evaluate_all_scores(nv: &NutritionVector) -> Result<ScoreResult, Vec<&'static str>> {
     let missing = nv.missing_fields();
     if !missing.is_empty() {
@@ -32,11 +31,12 @@ pub fn evaluate_allow_partial(nv: &NutritionVector) -> ScoreResult {
     for calc in calculators {
         let name = calc.name().to_string();
         let required = calc.required_fields();
-        let missing_fields: Vec<&str> = required
+        let mut missing_fields: Vec<&str> = required
             .iter()
             .copied()
             .filter(|f| missing.contains(f))
             .collect();
+        missing_fields.sort();
         let status = if missing_fields.is_empty() {
             ScorerStatus::Complete(calc.evaluate(nv))
         } else {

--- a/rust/src/scores/mod.rs
+++ b/rust/src/scores/mod.rs
@@ -3,7 +3,10 @@
 //! Partial evaluation is supported through [`evaluate_allow_partial`](crate::eval::evaluate_allow_partial).
 //! Each scorer returns a [`ScorerStatus`](crate::eval::ScorerStatus) indicating
 //! whether the score was computed or skipped. Skipped scores include a reason
-//! listing which input fields were missing.
+//! listing which input fields were missing. When running the CLI with
+//! `--allow-partial --verbose-partial`, skipped scores are grouped and printed
+//! in alphabetical order before the JSON result so missing fields are easy to
+//! spot.
 
 use crate::nutrition_vector::NutritionVector;
 


### PR DESCRIPTION
## Summary
- sort missing field names for deterministic Skipped reasons
- improve `--verbose-partial` CLI output with grouped skipped scores
- document verbose output behaviour in `scores/mod.rs`
- expand partial evaluation tests for edge cases and JSON validity

## Testing
- `cargo test --quiet`
- `pre-commit run --files rust/src/eval.rs rust/src/main.rs rust/src/scores/mod.rs rust/tests/score_tests.rs`

------
https://chatgpt.com/codex/tasks/task_b_68615ccabd5c833391fbe72a039e5fd5