### PR TITLE
Improve verbose partial output

### DIFF
--- a/rust/src/scores/mod.rs
+++ b/rust/src/scores/mod.rs
@@ -7,6 +7,8 @@
 //! `--allow-partial --verbose-partial`, skipped scores are grouped and printed
 //! in alphabetical order before the JSON result so missing fields are easy to
 //! spot.
+//! Helper functions like [`format_skipped_scores`](crate::eval::format_skipped_scores)
+//! can be used to present this information outside of the CLI.
 
 use crate::nutrition_vector::NutritionVector;
 


### PR DESCRIPTION
## Summary
- gather skipped score reasons via `format_skipped_scores`
- print grouped skipped scores in CLI
- verify alphabetical ordering and output stability in tests
- document helper in scoring module docs

## Testing
- `pre-commit run --all-files`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68615f2c51788333be95eee0f261e224