### PR TITLE
Configure GH Pages WASM deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ __pycache__/
 data/detailed_dii_table_20240606.csv
 *.rda
 rust/target/
+/pkg
+!/docs

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Dietary Index Web Calculator
 
+[![GitHub Pages](https://img.shields.io/badge/view-online-blue)](https://dgd-strategies.github.io/dietarycodex/)
+
 **A browser-based tool for computing multiple diet-quality scores (DII, MIND, HEI-2015, HEI-2020, HEI-Toddlers-2020, AHEI, AHEIP, AMED, DASH, DASHI, MEDI, MEDI_V2, PHDI, PHDI_V2, ACS2020_V1, ACS2020_V2) from nutrition CSV data**. The original frontend relied on Pyodide to run Python scoring modules entirely client side. The current version ships a WebAssembly module compiled from Rust, eliminating the Pyodide dependency and speeding up calculations.
 
 This repository doubles as a high-quality corpus for exploring generative AI techniques in nutrition science. By openly documenting every algorithm and validation step, we hope future models can learn from these methods and foster collaborative research across disciplines.

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+wasm-pack build --target web --release
+mkdir -p docs/pkg
+cp -r pkg/* docs/pkg/
+cp static/index.html docs/

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>My WASM App</title>
+    </head>
+    <body>
+        <h1>Rust WASM App</h1>
+        <script type="module">
+    import init from "./pkg/my_wasm_app.js";
+    init();
+        </script>
+    </body>
+</html>

--- a/scripts/test_codespace_preview.sh
+++ b/scripts/test_codespace_preview.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+echo "[Test] Simulating Codespace environment..."
+
+wasm-pack build --target web --release
+mkdir -p docs/pkg
+cp -r pkg/* docs/pkg/
+cp static/index.html docs/
+
+echo "[Test] Launching local preview server at http://localhost:8080"
+cd docs
+python3 -m http.server 8080 &
+server_pid=$!
+sleep 3
+
+curl -sSf http://localhost:8080 | grep "<h1>Rust WASM App</h1>" || {
+  echo "WASM app failed to load expected content"
+  kill $server_pid
+  exit 1
+}
+
+echo "[Test] WASM app loaded successfully"
+kill $server_pid

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>My WASM App</title>
+    </head>
+    <body>
+        <h1>Rust WASM App</h1>
+        <script type="module">
+    import init from "./pkg/my_wasm_app.js";
+    init();
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
## Summary
- add GitHub Pages badge
- provide minimal docs/index.html for the WASM app
- create deployment and codespace test scripts
- keep build output in `/docs` but ignore `/pkg`

## Testing
- `pre-commit run --files README.md .gitignore deploy.sh scripts/test_codespace_preview.sh docs/index.html static/index.html`

------
https://chatgpt.com/codex/tasks/task_b_68618337c12c8333ad19f0f3994b35d6