### PR TITLE
Fix Docker build and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: 🧾 Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 🐍 Set up Python
         uses: actions/setup-python@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ COPY .pre-commit-config.yaml .
 # Copy project directories
 COPY compute/ compute/
 COPY tests/ tests/
-COPY index.html index.html
+# Copy the static HTML entry point
+COPY static/index.html index.html
 COPY assets/ assets/
 COPY docs/ docs/
 COPY setup.sh setup.sh


### PR DESCRIPTION
## Summary
- fix Dockerfile to copy HTML from `static` directory
- bump checkout action to v4 in CI workflow

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_b_686190d32a0483338d9ad85613cdc4e0