### PR TITLE
Fix wasm-pack build path in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,12 +28,12 @@ jobs:
         run: cargo install wasm-pack
 
       - name: Build with wasm-pack
-        run: wasm-pack build --target web --release
+        run: cd rust && wasm-pack build --target web --release
 
       - name: Copy files to dist/
         run: |
           mkdir -p dist/pkg
-          cp -r pkg/* dist/pkg/
+          cp -r rust/pkg/* dist/pkg/
           cp static/index.html dist/
 
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- build the WASM package from the `rust` crate
- copy built files from `rust/pkg` for Pages deployment

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_b_686194ca0b108333b4aafc88254a8080