### PR TITLE
Fix scoring path & add template check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,3 +43,8 @@ repos:
         entry: pytest -q
         language: system
         pass_filenames: false
+      - id: check-template
+        name: validate template csv
+        entry: bash scripts/check_template_scores.sh
+        language: system
+        pass_filenames: false

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
               rel="stylesheet" />
         <script src="https://cdn.plot.ly/plotly-2.32.0.min.js"></script>
-        <script type="module">import init from './pkg/dietarycodex.js'; init();</script>
+        <script type="module">import init from './assets/wasm/dietarycodex.js'; init();</script>
         <script>if ("serviceWorker" in navigator){navigator.serviceWorker.register("sw.js").catch(()=>{});}</script>
         <link href="assets/style.css" rel="stylesheet" />
     </head>
@@ -128,7 +128,7 @@
     let scoredCsv = null;
     async function loadWasm() {
       if (!wasmReady) {
-        wasmReady = import('./pkg/dietarycodex.js')
+        wasmReady = import('./assets/wasm/dietarycodex.js')
           .then(async m => {
             await m.default();
             return m;

--- a/scripts/check_template_scores.sh
+++ b/scripts/check_template_scores.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+node scripts/validate_template.mjs | jq -e 'length > 0 and (.[0] | length > 0)' >/dev/null

--- a/scripts/validate_template.mjs
+++ b/scripts/validate_template.mjs
@@ -1,0 +1,27 @@
+import fs from 'fs';
+import { initSync, score_json } from '../assets/wasm/dietarycodex.js';
+
+const wasmB64 = fs.readFileSync(new URL('../assets/wasm/dietarycodex_bg.wasm.b64', import.meta.url), 'utf8');
+initSync(Buffer.from(wasmB64, 'base64'));
+
+const csv = fs.readFileSync(new URL('../data/template.csv', import.meta.url), 'utf8');
+const lines = csv.trim().split(/\r?\n/);
+const headers = lines[0].split(',');
+const rows = lines.slice(1).map(line => {
+  const values = line.split(',');
+  const obj = {};
+  headers.forEach((h, i) => {
+    const v = values[i]?.trim();
+    if (v === '') {
+      obj[h] = null;
+    } else {
+      const num = Number(v);
+      obj[h] = Number.isNaN(num) ? v : num;
+    }
+  });
+  return obj;
+});
+
+const raw = score_json(JSON.stringify(rows));
+const data = raw.map(m => Object.fromEntries(m));
+console.log(JSON.stringify(data));


### PR DESCRIPTION
## Summary
- fix WASM import path in `index.html`
- verify template CSV can be scored via new pre-commit hook
- implement `validate_template.mjs` Node helper

## Testing
- `pre-commit run --files index.html .pre-commit-config.yaml scripts/validate_template.mjs scripts/check_template_scores.sh`

------
https://chatgpt.com/codex/tasks/task_b_6862fc114350833385594397462ae7f1