### PR TITLE
Fix WASM init path and add preview validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,8 @@ repos:
         entry: bash scripts/check_template_scores.sh
         language: system
         pass_filenames: false
+      - id: preview-build
+        name: build preview site
+        entry: bash scripts/premerge_preview.sh
+        language: system
+        pass_filenames: false

--- a/index.html
+++ b/index.html
@@ -11,7 +11,10 @@
               rel="stylesheet" />
         <script src="https://cdn.plot.ly/plotly-2.32.0.min.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-        <script type="module">import init from './assets/wasm/dietarycodex.js'; init();</script>
+        <script type="module">
+          import init from './pkg/dietarycodex.js';
+          init().catch(() => import('./assets/wasm/dietarycodex.js').then(m => m.default()));
+        </script>
         <script>if ("serviceWorker" in navigator){navigator.serviceWorker.register("sw.js").catch(()=>{});}</script>
         <link href="assets/style.css" rel="stylesheet" />
     </head>
@@ -149,7 +152,9 @@
     let scoredCsv = null;
     async function loadWasm() {
       if (!wasmReady) {
-        wasmReady = import('./assets/wasm/dietarycodex.js')
+        const load = () => import('./pkg/dietarycodex.js')
+          .catch(() => import('./assets/wasm/dietarycodex.js'));
+        wasmReady = load()
           .then(async m => {
             await m.default();
             return m;

--- a/scripts/premerge_preview.sh
+++ b/scripts/premerge_preview.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build minimal preview directory
+TMPDIR=$(mktemp -d)
+mkdir -p "$TMPDIR/pkg" "$TMPDIR/assets" "$TMPDIR/data"
+cp index.html "$TMPDIR/"
+cp sw.js "$TMPDIR/"
+cp -r assets/* "$TMPDIR/assets/"
+cp data/template.csv "$TMPDIR/data/"
+base64 -d assets/wasm/dietarycodex_bg.wasm.b64 > "$TMPDIR/pkg/dietarycodex_bg.wasm"
+cp assets/wasm/dietarycodex.js "$TMPDIR/pkg/"
+
+# Verify scoring works
+node scripts/validate_template.mjs >/dev/null
+
+# Start local server and check page loads
+python3 -m http.server -d "$TMPDIR" 8080 &
+PID=$!
+sleep 3
+curl -sSf http://localhost:8080/index.html | grep -q "Loading WASM"
+kill $PID
+
+echo "[Validation] Preview built successfully"


### PR DESCRIPTION
## Summary
- load WASM from `pkg/` with fallback to existing assets
- add a preview build script for CI validation
- run preview build in pre-commit hooks

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_b_68630094d0688333b7302034f8c343db