### PR TITLE
Fix scoring output for wasm

### DIFF
--- a/index.html
+++ b/index.html
@@ -350,7 +350,8 @@
           downloadBtn.disabled = true;
           return;
         }
-        const scoreRows = wasm.score_json(JSON.stringify(mapped));
+        const rawRows = wasm.score_json(JSON.stringify(mapped));
+        const scoreRows = rawRows.map(r => Object.fromEntries(r));
         const combined = mapped.map((r,i) => ({...r, ...(scoreRows[i]||{})}));
         const csvText = jsonToCsv(combined);
         const scoreNames = Object.keys(scoreRows[0] || {});

--- a/scripts/check_template_scores.sh
+++ b/scripts/check_template_scores.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-node scripts/validate_template.mjs | jq -e 'length > 0 and (.[0] | length > 0)' >/dev/null
+out=$(node scripts/validate_template.mjs)
+echo "$out" | jq -e 'length > 0 and .[0].DII != null' >/dev/null

--- a/tests/test_wasm_output.py
+++ b/tests/test_wasm_output.py
@@ -1,0 +1,55 @@
+import subprocess
+from pathlib import Path
+
+
+def test_score_json_plain_objects(tmp_path):
+    script = tmp_path / "run.js"
+    repo = Path(__file__).resolve().parents[1]
+    script.write_text(
+        f"""
+const fs = require('fs');
+const {{ initSync, score_json }} = require('{repo}/assets/wasm/dietarycodex.js');
+const b64 = fs.readFileSync('{repo}/assets/wasm/dietarycodex_bg.wasm.b64', 'utf8');
+initSync(Buffer.from(b64, 'base64'));
+const data = JSON.stringify([{{
+  energy_kcal: 1,
+  fat_g: 1,
+  saturated_fat_g: 1,
+  carbs_g: 1,
+  fiber_g: 1,
+  sugar_g: 1,
+  protein_g: 1,
+  sodium_mg: 1,
+  calcium_mg: 1,
+  iron_mg: 1,
+  vitamin_c_mg: 1,
+  total_fruits_g: 1,
+  vegetables_g: 1,
+  whole_grains_g: 1,
+  refined_grains_g: 1,
+  legumes_g: 1,
+  fish_g: 1,
+  red_meat_g: 1,
+  mono_fat_g: 1,
+  berries_g: 1,
+  cheese_g: 1,
+  butter_g: 1,
+  poultry_g: 1,
+  fast_food_g: 1,
+  nuts_g: 1,
+  omega3_g: 1,
+  vitamin_a_mcg: 1,
+  vitamin_e_mg: 1,
+  zinc_mg: 1,
+  selenium_mcg: 1,
+  magnesium_mg: 1,
+  trans_fat_g: 1,
+  alcohol_g: 1
+}}]);
+const raw = score_json(data);
+const plain = raw.map(r => Object.fromEntries(r));
+console.log(plain[0].DII !== undefined);
+"""
+    )
+    output = subprocess.check_output(["node", script], text=True).strip()
+    assert output == "true"


### PR DESCRIPTION
## Summary
- convert Map results from wasm to plain objects so summary stats render
- tighten template validation script to verify DII output
- add JS test ensuring Map results are transformed correctly

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_b_686304d589308333b5fd66ae4fdb8c9b