### PR TITLE
Add ACS2020_V3 index support

### DIFF
--- a/compute/__init__.py
+++ b/compute/__init__.py
@@ -3,8 +3,10 @@ __version__ = "0.1.0"
 from .acs2020 import (  # noqa: F401
     ACS2020_V1_KEYS,
     ACS2020_V2_KEYS,
+    ACS2020_V3_KEYS,
     calculate_acs2020_v1,
     calculate_acs2020_v2,
+    calculate_acs2020_v3,
 )
 from .ahei import AHEI_COMPONENT_KEYS, calculate_ahei  # noqa: F401
 from .aheip import AHEIP_COMPONENT_KEYS, calculate_aheip  # noqa: F401

--- a/compute/acs2020.py
+++ b/compute/acs2020.py
@@ -21,6 +21,9 @@ ACS2020_V2_KEYS = ACS2020_V1_KEYS[:-2] + [
     "TOTALKCAL_ACS2020",
 ]
 
+# Placeholder components for a future ACS2020 version 3 implementation.
+ACS2020_V3_KEYS = ACS2020_V2_KEYS
+
 
 def _quartile_ranks(series: pd.Series, gender: pd.Series) -> pd.Series:
     def rank_group(s: pd.Series) -> pd.Series:
@@ -114,3 +117,13 @@ def calculate_acs2020_v2(df: pd.DataFrame) -> pd.Series:
 
     total = veg + veg_items + frt + frt_items + wgrain + red_meat + hpfrg + ssb
     return total
+
+
+def calculate_acs2020_v3(df: pd.DataFrame) -> pd.Series:
+    """Placeholder for ACS2020 version 3.
+
+    This stub reuses the version 2 algorithm until official cut points are
+    finalized.
+    """
+    validate_dataframe(df, ACS2020_V3_KEYS)
+    return calculate_acs2020_v2(df)

--- a/compute/api.py
+++ b/compute/api.py
@@ -14,8 +14,10 @@ from fastapi.staticfiles import StaticFiles
 from compute.acs2020 import (
     ACS2020_V1_KEYS,
     ACS2020_V2_KEYS,
+    ACS2020_V3_KEYS,
     calculate_acs2020_v1,
     calculate_acs2020_v2,
+    calculate_acs2020_v3,
 )
 from compute.ahei import AHEI_COMPONENT_KEYS, calculate_ahei
 from compute.aheip import AHEIP_COMPONENT_KEYS, calculate_aheip
@@ -74,6 +76,7 @@ REQUIRED_COLS = (
     + PHDI_V2_COMPONENT_KEYS
     + ACS2020_V1_KEYS
     + ACS2020_V2_KEYS
+    + ACS2020_V3_KEYS
 )
 
 app = FastAPI(
@@ -185,6 +188,9 @@ async def score_diet_indices(
     if "ACS2020_V2" in indices:
         logger.info("Computing ACS2020_V2...")
         results["ACS2020_V2"] = calculate_acs2020_v2(df)
+    if "ACS2020_V3" in indices:
+        logger.info("Computing ACS2020_V3...")
+        results["ACS2020_V3"] = calculate_acs2020_v3(df)
 
     # Attach results to DataFrame
     for name, series in results.items():

--- a/openapi.yml
+++ b/openapi.yml
@@ -28,7 +28,7 @@ paths:
           in: query
           description: |
             Optional comma-separated list of indices to compute.
-            Valid values: DII, MIND, HEI_2015, HEI_2020, HEI_TODDLERS_2020, DASH, AHEI, MEDI, PHDI, ACS2020_V1, ACS2020_V2.
+            Valid values: DII, MIND, HEI_2015, HEI_2020, HEI_TODDLERS_2020, DASH, AHEI, MEDI, PHDI, ACS2020_V1, ACS2020_V2, ACS2020_V3.
           required: false
           schema:
             type: array

--- a/tests/test_api_acs2020_v3.py
+++ b/tests/test_api_acs2020_v3.py
@@ -1,0 +1,25 @@
+import pandas as pd
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+from compute.api import app
+from compute.acs2020 import ACS2020_V3_KEYS
+
+client = TestClient(app)
+
+def make_df(n=2):
+    df = pd.DataFrame({col: [1] * n for col in ACS2020_V3_KEYS})
+    df["gender"] = 1
+    df["TOTALKCAL_ACS2020"] = 2000
+    return df
+
+def test_acs2020_v3_invoked(tmp_path):
+    df = make_df()
+    with patch("compute.api.calculate_acs2020_v3") as mock_calc:
+        mock_calc.return_value = pd.Series([1] * len(df))
+        response = client.post(
+            "/score?indices=ACS2020_V3",
+            files={"file": ("test.csv", df.to_csv(index=False), "text/csv")},
+        )
+        assert response.status_code == 200
+        mock_calc.assert_called_once()


### PR DESCRIPTION
## Summary
- implement placeholder `calculate_acs2020_v3`
- wire new index into API and expose in package
- document ACS2020_V3 in OpenAPI
- verify API invocation via new unit test

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_b_68630e36ec7083339b758479ff34e5a9