### PR TITLE
Add variance check and fallback detection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,3 +53,8 @@ repos:
         entry: bash scripts/premerge_preview.sh
         language: system
         pass_filenames: false
+      - id: wasm-fallback-check
+        name: detect Rust fallback
+        entry: bash scripts/check_wasm_fallback.sh
+        language: system
+        pass_filenames: false

--- a/docs/README.md
+++ b/docs/README.md
@@ -182,6 +182,8 @@ index scores.
 
 CI checks that every run produces non-null scores for required indices such as
 `ACS2020`, `DII`, and `AHEI`. Blank or flat results trigger a failure condition.
+Unit tests also verify that computed index values vary across rows rather than
+remaining constant.
 Snapshot or range-based comparisons may be added to ensure results stay within
 expected bounds over time.
 

--- a/scripts/check_wasm_fallback.sh
+++ b/scripts/check_wasm_fallback.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+# Run the Node validator using the compiled WASM module
+if ! node scripts/validate_template.mjs >/dev/null 2>&1; then
+  echo "Rust WASM scoring failed or Python fallback triggered" >&2
+  exit 1
+fi
+
+echo "[Validation] Rust scoring path confirmed"

--- a/tests/test_output_variance.py
+++ b/tests/test_output_variance.py
@@ -1,0 +1,17 @@
+import pandas as pd
+
+from compute.ahei import AHEI_COMPONENT_KEYS, calculate_ahei
+from compute.dash import DASH_COMPONENT_KEYS, calculate_dash
+
+
+def test_output_variance_dash_ahei():
+    n = 5
+    dash_df = pd.DataFrame({c: range(1, n + 1) for c in DASH_COMPONENT_KEYS})
+    dash_scores = calculate_dash(dash_df)
+    assert dash_scores.nunique() > 1
+
+    cols = {c: range(1, n + 1) for c in AHEI_COMPONENT_KEYS}
+    cols["gender"] = [1] * n
+    ahei_df = pd.DataFrame(cols)
+    ahei_scores = calculate_ahei(ahei_df)
+    assert ahei_scores.nunique() > 1


### PR DESCRIPTION
## Summary
- ensure WASM scoring path during pre-commit with `check_wasm_fallback.sh`
- add a unit test asserting score variance for DASH and AHEI
- document that tests verify non-null, non-constant results
- commit referencing enforcement directive Q3.3-RUST-SCORING-INTEGRITY

## Testing
- `pre-commit run --files .pre-commit-config.yaml scripts/check_wasm_fallback.sh tests/test_output_variance.py docs/README.md`

------
https://chatgpt.com/codex/tasks/task_b_686313e111c88333b22ad96c89c228be