### PR TITLE
Add sorting check for NutritionVector field names

### DIFF
--- a/rust/tests/score_tests.rs
+++ b/rust/tests/score_tests.rs
@@ -304,6 +304,14 @@ fn metadata_sorted() {
     }
 }
 
+#[test]
+fn all_field_names_sorted() {
+    let fields = NutritionVector::all_field_names();
+    let mut sorted = fields.to_vec();
+    sorted.sort();
+    assert_eq!(fields, sorted.as_slice());
+}
+
 fn all_fields_nv() -> NutritionVector {
     NutritionVector {
         energy_kcal: Some(2000.0),


### PR DESCRIPTION
## Summary
- verify `NutritionVector::all_field_names` order in Rust tests

## Testing
- `pre-commit run --files rust/tests/score_tests.rs`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6863189367108333b57271eaf98d309b