### PR TITLE
Fix computeStats for small samples

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,9 +178,13 @@
     }
     function computeStats(values) {
       const n = values.length;
+      if (!n) return null;
       const mean = values.reduce((a,b) => a + b, 0) / n;
-      const sq = values.map(v => (v - mean)**2);
-      const std = Math.sqrt(sq.reduce((a,b) => a + b, 0) / (n - 1));
+      let std = 0;
+      if (n > 1) {
+        const sq = values.map(v => (v - mean)**2);
+        std = Math.sqrt(sq.reduce((a,b) => a + b, 0) / (n - 1));
+      }
       return {
         mean: mean.toFixed(2),
         std: std.toFixed(2),


### PR DESCRIPTION
## Summary
- avoid division by zero when computing standard deviation in JS

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_b_68631e5f47e883339eb08528506b73c0