### PR TITLE
Add canonical mapping and schema validation tests

### DIFF
--- a/rust/src/wasm.rs
+++ b/rust/src/wasm.rs
@@ -1,5 +1,4 @@
 use wasm_bindgen::prelude::*;
-use serde::{Deserialize, Serialize};
 use serde_json;
 use console_error_panic_hook;
 use crate::nutrition_vector::NutritionVector;

--- a/rust/tests/schema_validation.rs
+++ b/rust/tests/schema_validation.rs
@@ -1,0 +1,43 @@
+use dietarycodex::nutrition_vector::NutritionVector;
+use std::collections::HashMap;
+
+fn full_map() -> HashMap<String, f64> {
+    let mut m = HashMap::new();
+    for field in NutritionVector::all_field_names() {
+        m.insert((*field).to_string(), 1.0);
+    }
+    m
+}
+
+#[test]
+fn load_canonical_fields() {
+    let map = full_map();
+    let nv = NutritionVector::from_map(&map).expect("should load");
+    assert!(nv.missing_fields().is_empty());
+}
+
+#[test]
+fn load_with_aliases() {
+    let mut map = HashMap::new();
+    for field in NutritionVector::all_field_names() {
+        let key = match *field {
+            "alcohol_g" => "alc",
+            "energy_kcal" => "kcal",
+            "sodium_mg" => "sodium",
+            _ => field,
+        };
+        map.insert(key.to_string(), 1.0);
+    }
+    let nv = NutritionVector::from_map(&map).expect("aliases should map");
+    assert!(nv.missing_fields().is_empty());
+}
+
+#[test]
+fn unmapped_field_fails() {
+    let mut map = full_map();
+    map.remove("alcohol_g");
+    map.insert("alcohol_content".to_string(), 1.0);
+    let err = NutritionVector::from_map(&map).unwrap_err();
+    assert!(err.missing_fields.contains(&"alcohol_g"));
+    assert!(err.suggestions.iter().any(|(a, c)| a == "alcohol_content" && *c == "alcohol_g"));
+}

--- a/schema/field_aliases.json
+++ b/schema/field_aliases.json
@@ -1,0 +1,11 @@
+{
+  "alc": "alcohol_g",
+  "alcohol": "alcohol_g",
+  "alcohol_intake": "alcohol_g",
+  "alcohol_g": "alcohol_g",
+  "energy": "energy_kcal",
+  "kcal": "energy_kcal",
+  "calories": "energy_kcal",
+  "sodium": "sodium_mg",
+  "sodium_mg": "sodium_mg"
+}


### PR DESCRIPTION
## Summary
- map common aliases to canonical nutrition fields
- provide `from_map` helper for validating input
- test canonical mapping paths
- remove unused import in WASM module
- add JSON listing field aliases

## Testing
- `cargo test -q`
- `pre-commit run --files rust/src/nutrition_vector.rs rust/src/wasm.rs rust/tests/schema_validation.rs schema/field_aliases.json` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68632e954ac88333b01f27948d0aca44