### PR TITLE
Add scoring contracts doc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,3 +83,26 @@ Deliver a web page that runs entirely client side. Users should upload any CSV a
 ## UI Standard
 - Keep note of "AGENT_STYLE.md" particularly built for OpenAI Codex
 - This file keeps track and organizes the owner's central OKRs required in styling
+
+## Q3.3 - RUST-SCORING-INTEGRITY
+This phase enforces output validation in the Rust scoring engine and ensures every index produces a valid number. A new document [`docs/SCORING_CONTRACTS.md`](docs/SCORING_CONTRACTS.md) lists expected ranges and required fields.
+
+### Test Coverage Matrix
+| Index | Dummy Rows |
+|-------|-----------|
+| DII | 5 |
+| HEI_2015 | 8 |
+| HEI_2020 | 5 |
+| HEI_TODDLERS_2020 | 4 |
+| MIND | 7 |
+| DASH | 6 |
+| DASHI | 5 |
+| AHEI | 6 |
+| AHEIP | 5 |
+| AMED | 5 |
+| MEDI | 4 |
+| MEDI_V2 | 4 |
+| PHDI | 3 |
+| ACS2020_V1 | 2 |
+| ACS2020_V2 | 2 |
+| ACS2020_V3 | 2 |

--- a/docs/SCORING_CONTRACTS.md
+++ b/docs/SCORING_CONTRACTS.md
@@ -1,0 +1,25 @@
+# Scoring Contracts
+
+This document formalizes the expected output for each supported dietary index. For every index the table lists the approximate score range, the set of required input fields, and whether any fallback is allowed when fields are missing.
+
+| Index | Typical Range | Required Inputs | Fallbacks |
+|-------|---------------|-----------------|-----------|
+| DII | ~-9 to +9 | `DII_PARAMETER_KEYS` | none |
+| MIND | 0–15 | `MIND_COMPONENT_KEYS` | none |
+| HEI_2015 | 0–100 | `HEI_COMPONENT_KEYS` + `energy_kcal` | none |
+| HEI_2020 | 0–100 | `HEI_COMPONENT_KEYS` + `energy_kcal` | none |
+| HEI_TODDLERS_2020 | 0–100 | `HEI_COMPONENT_KEYS` + `energy_kcal` | none |
+| AHEI | 0–110 | `AHEI_COMPONENT_KEYS` + `gender` | none |
+| AHEIP | 0–90 | `AHEIP_COMPONENT_KEYS` | none |
+| AMED | 0–9 | `AMED_COMPONENT_KEYS` | none |
+| DASH | 8–40 | `DASH_COMPONENT_KEYS` | none |
+| DASHI | 0–8 | `DASHI_COMPONENT_KEYS` | none |
+| MEDI | 0–9 | `MEDI_COMPONENT_KEYS` | none |
+| MEDI_V2 | 0–15 | `MEDI_V2_COMPONENT_KEYS` | none |
+| PHDI | 0–15 | `PHDI_COMPONENT_KEYS` + `gender` | none |
+| PHDI_V2 | 0–15 | `PHDI_V2_COMPONENT_KEYS` + `gender` | none |
+| ACS2020_V1 | 0–15 | `ACS2020_V1_KEYS` + `gender` | none |
+| ACS2020_V2 | 0–15 | `ACS2020_V2_KEYS` + `gender` | none |
+| ACS2020_V3 | 0–15 | `ACS2020_V3_KEYS` + `gender` | none |
+
+These ranges are approximate based on published methods. The Rust engine will emit structured errors if required fields are missing. No automatic fallback is permitted; all indices must receive complete data.


### PR DESCRIPTION
## Summary
- define scoring expectations per index in `docs/SCORING_CONTRACTS.md`
- document progress on Q3.3 scoring integrity in `AGENTS.md`

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_b_6863362b7ae88333af6a3922360d99bd