### PR TITLE
Normalize CSV ingestion based on template headers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,11 @@ Deliver a web page that runs entirely client side. Users should upload any CSV a
 ## Q3.3 - RUST-SCORING-INTEGRITY
 This phase enforces output validation in the Rust scoring engine and ensures every index produces a valid number. A new document [`docs/SCORING_CONTRACTS.md`](docs/SCORING_CONTRACTS.md) lists expected ranges and required fields.
 
+### Canonical Input Schema
+* `data/template.csv` defines the authoritative header names and order.
+* All aliases listed in `schema/field_aliases.json` are resolved once at ingest
+  time, producing this canonical set.
+
 ### Test Coverage Matrix
 | Index | Dummy Rows |
 |-------|-----------|

--- a/rust/src/wasm.rs
+++ b/rust/src/wasm.rs
@@ -20,6 +20,7 @@ pub fn score_json(json: &str) -> Result<JsValue, JsValue> {
         scores: std::collections::BTreeMap<String, Option<f64>>,
         validity: std::collections::BTreeMap<String, (bool, Option<String>)>,
         trace: InputTrace,
+        errors: Vec<crate::eval::IndexError>,
     }
 
     let mut out: Vec<RowOutput> = Vec::new();
@@ -56,6 +57,7 @@ pub fn score_json(json: &str) -> Result<JsValue, JsValue> {
             scores: scores_map,
             validity: validity_map,
             trace: result.trace,
+            errors: result.errors,
         });
     }
 

--- a/rust/tests/normalization_tests.rs
+++ b/rust/tests/normalization_tests.rs
@@ -1,0 +1,68 @@
+use dietarycodex::eval::evaluate_allow_partial;
+use dietarycodex::nutrition_vector::NutritionVector;
+use serde_json::Value;
+use std::collections::HashMap;
+
+#[test]
+fn noisy_aliases_normalize_and_score() {
+    let mut map = HashMap::new();
+    map.insert("kcal".to_string(), Value::from(1800.0));
+    map.insert("fat".to_string(), Value::from(60.0));
+    map.insert("saturated_fat".to_string(), Value::from(15.0));
+    map.insert("carbohydrate".to_string(), Value::from(200.0));
+    map.insert("fiber".to_string(), Value::from(25.0));
+    map.insert("sugars".to_string(), Value::from(40.0));
+    map.insert("protein_g".to_string(), Value::from(50.0));
+    map.insert("sodium_mg".to_string(), Value::from(1500.0));
+    map.insert("calcium_mg".to_string(), Value::from(900.0));
+    map.insert("iron_mg".to_string(), Value::from(10.0));
+    map.insert("vitamin_c_mg".to_string(), Value::from(60.0));
+    map.insert("total_fruits_g".to_string(), Value::from(200.0));
+    map.insert("vegetables_g".to_string(), Value::from(250.0));
+    map.insert("whole_grains_g".to_string(), Value::from(90.0));
+    map.insert("refined_grains_g".to_string(), Value::from(80.0));
+    map.insert("legumes_g".to_string(), Value::from(30.0));
+    map.insert("fish_g".to_string(), Value::from(20.0));
+    map.insert("red_meat_g".to_string(), Value::from(30.0));
+    map.insert("mono_fat_g".to_string(), Value::from(25.0));
+    map.insert("berries_g".to_string(), Value::from(5.0));
+    map.insert("cheese_g".to_string(), Value::from(15.0));
+    map.insert("butter_g".to_string(), Value::from(5.0));
+    map.insert("poultry_g".to_string(), Value::from(40.0));
+    map.insert("fast_food_g".to_string(), Value::from(0.0));
+    map.insert("nuts_g".to_string(), Value::from(10.0));
+    map.insert("omega3_g".to_string(), Value::from(1.0));
+    map.insert("vitamin_a_mcg".to_string(), Value::from(800.0));
+    map.insert("vitamin_e_mg".to_string(), Value::from(10.0));
+    map.insert("zinc_mg".to_string(), Value::from(12.0));
+    map.insert("selenium_mcg".to_string(), Value::from(55.0));
+    map.insert("magnesium_mg".to_string(), Value::from(300.0));
+    map.insert("trans_fat_g".to_string(), Value::from(0.1));
+    map.insert("alcohol_intake".to_string(), Value::from(2.0));
+
+    let (nv, _trace) = NutritionVector::from_partial_map(&map);
+    let result = evaluate_allow_partial(&nv);
+    assert!(result.scores.values().any(|s| s.value.is_some()));
+}
+
+#[test]
+fn duplicate_fields_prefers_canonical() {
+    let mut map = HashMap::new();
+    map.insert("carbs_g".to_string(), Value::from(100.0));
+    map.insert("carbohydrate".to_string(), Value::from(150.0));
+    let (nv, trace) = NutritionVector::from_partial_map(&map);
+    assert_eq!(nv.carbs_g, Some(100.0));
+    assert!(trace.conflicting_aliases.contains(&("carbohydrate".to_string(), "carbs_g")));
+}
+
+#[test]
+fn missing_canonical_field_errors() {
+    let mut map: HashMap<String, f64> = HashMap::new();
+    for f in NutritionVector::all_field_names() {
+        if *f != "fat_g" {
+            map.insert(f.to_string(), 1.0);
+        }
+    }
+    let err = NutritionVector::from_map(&map).unwrap_err();
+    assert!(err.missing_canonical_fields.contains(&"fat_g"));
+}

--- a/rust/tests/score_tests.rs
+++ b/rust/tests/score_tests.rs
@@ -307,11 +307,26 @@ fn metadata_sorted() {
 }
 
 #[test]
-fn all_field_names_sorted() {
+fn all_field_names_match_template_order() {
     let fields = NutritionVector::all_field_names();
-    let mut sorted = fields.to_vec();
-    sorted.sort();
-    assert_eq!(fields, sorted.as_slice());
+    let template = {
+        let line = std::fs::read_to_string("../data/template.csv")
+            .expect("read template");
+        line.lines()
+            .next()
+            .unwrap()
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .collect::<Vec<String>>()
+    };
+    let mut canon_in_template = Vec::new();
+    for name in template {
+        if fields.contains(&name.as_str()) {
+            canon_in_template.push(name);
+        }
+    }
+    let from_fn: Vec<&str> = fields.to_vec();
+    assert_eq!(from_fn, canon_in_template.iter().map(|s| s.as_str()).collect::<Vec<_>>());
 }
 
 fn all_fields_nv() -> NutritionVector {


### PR DESCRIPTION
## Summary
- enforce canonical header order from `data/template.csv`
- normalize duplicate aliases with canonical priority and log conflicts
- add structured index errors for missing fields
- expose errors in WASM output
- document canonical schema rules
- test header normalization logic

## Testing
- `pre-commit run --files AGENTS.md rust/src/eval.rs rust/src/nutrition_vector.rs rust/src/wasm.rs rust/tests/normalization_tests.rs rust/tests/score_tests.rs`


------
https://chatgpt.com/codex/tasks/task_b_68639d91f30c8333872cc3de5852764b