### PR TITLE
Add food item resolver framework

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,6 +15,7 @@ tabwriter = "1"
 wasm-bindgen = "0.2"
 serde-wasm-bindgen = "0.6"
 console_error_panic_hook = "0.1"
+log = "0.4"
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/rust/src/food_item_resolver.rs
+++ b/rust/src/food_item_resolver.rs
@@ -1,0 +1,58 @@
+use once_cell::sync::Lazy;
+use serde::Deserialize;
+use std::collections::HashMap;
+use log::info;
+
+static FOOD_JSON: &str = include_str!("../../schema/food_components.json");
+
+#[derive(Debug, Deserialize)]
+struct RawMap(HashMap<String, HashMap<String, f64>>);
+
+pub struct FoodItemResolver {
+    map: HashMap<&'static str, HashMap<&'static str, f64>>,
+}
+
+impl FoodItemResolver {
+    fn load() -> Self {
+        let raw: HashMap<String, HashMap<String, f64>> = serde_json::from_str(FOOD_JSON)
+            .expect("invalid food_components.json");
+        let mut map = HashMap::new();
+        for (item, comps) in raw {
+            let key: &'static str = Box::leak(item.to_ascii_lowercase().into_boxed_str());
+            let mut inner = HashMap::new();
+            for (nut, val) in comps {
+                let nut_key: &'static str = Box::leak(nut.to_string().into_boxed_str());
+                inner.insert(nut_key, val);
+            }
+            map.insert(key, inner);
+        }
+        FoodItemResolver { map }
+    }
+
+    pub fn resolve(&self, field: &str, amount: f64) -> Option<HashMap<&'static str, f64>> {
+        let lower = field.to_ascii_lowercase();
+        if lower.ends_with("_g") {
+            let base = lower.trim_end_matches("_g");
+            self.map.get(base).map(|comp| {
+                comp.iter()
+                    .map(|(k, v)| (*k, v * amount / 100.0))
+                    .collect()
+            })
+        } else if lower.ends_with("_servings") {
+            let base = lower.trim_end_matches("_servings");
+            self.map.get(base).map(|comp| {
+                comp.iter().map(|(k, v)| (*k, v * amount)).collect()
+            })
+        } else {
+            None
+        }
+    }
+}
+
+pub static FOOD_RESOLVER: Lazy<FoodItemResolver> = Lazy::new(FoodItemResolver::load);
+
+#[derive(Debug, Default, Clone, serde::Serialize, PartialEq)]
+pub struct TranslationEntry {
+    pub value: f64,
+    pub source: Vec<String>,
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -6,3 +6,4 @@ pub mod nhanes_ingest;
 pub mod acs2020_ingest;
 pub mod hcsn_ingest;
 pub mod wasm;
+pub mod food_item_resolver;

--- a/rust/src/wasm.rs
+++ b/rust/src/wasm.rs
@@ -80,6 +80,7 @@ pub fn score_json(json: &str) -> Result<JsValue, JsValue> {
         let mut result = evaluate_allow_partial(&nv);
         result.trace.aliases_applied = trace.aliases_applied.clone();
         result.trace.conflicting_aliases = trace.conflicting_aliases.clone();
+        result.trace.translation_log = trace.translation_log.clone();
 
         for field in &result.trace.missing_fields {
             *missing_counts.entry(*field).or_insert(0) += 1;

--- a/rust/tests/food_resolver.rs
+++ b/rust/tests/food_resolver.rs
@@ -1,0 +1,40 @@
+use dietarycodex::nutrition_vector::NutritionVector;
+use dietarycodex::eval::evaluate_allow_partial;
+use serde_json::Value;
+use std::collections::HashMap;
+
+#[test]
+fn raw_item_only_resolves() {
+    let mut map = HashMap::new();
+    map.insert("beef_g".to_string(), Value::from(100.0));
+    let (nv, trace) = NutritionVector::from_partial_map(&map);
+    assert_eq!(nv.protein_g, Some(26.0));
+    assert!(trace
+        .translation_log
+        .get("protein_g")
+        .unwrap()
+        .source
+        .contains(&"beef_g".to_string()));
+    let result = evaluate_allow_partial(&nv);
+    assert!(result.scores.values().all(|s| s.value.is_none()));
+}
+
+#[test]
+fn raw_and_canonical_combined() {
+    let mut map = HashMap::new();
+    map.insert("beef_g".to_string(), Value::from(100.0));
+    map.insert("protein_g".to_string(), Value::from(10.0));
+    let (nv, trace) = NutritionVector::from_partial_map(&map);
+    assert_eq!(nv.protein_g, Some(36.0));
+    assert_eq!(trace.translation_log.get("protein_g").unwrap().value, 26.0);
+}
+
+#[test]
+fn empty_input_gives_errors() {
+    let map: HashMap<String, Value> = HashMap::new();
+    let (nv, trace) = NutritionVector::from_partial_map(&map);
+    assert!(trace.missing_fields.contains(&"energy_kcal"));
+    let result = evaluate_allow_partial(&nv);
+    assert!(result.scores.values().all(|s| s.value.is_none()));
+    assert!(!result.errors.is_empty());
+}

--- a/schema/food_components.json
+++ b/schema/food_components.json
@@ -1,0 +1,9 @@
+{
+  "beef": {
+    "protein_g": 26.0,
+    "saturated_fat_g": 6.0,
+    "iron_mg": 2.1,
+    "red_meat_g": 100.0,
+    "animal_protein_g": 100.0
+  }
+}


### PR DESCRIPTION
## Summary
- define initial food component schema for decomposition
- add `FoodItemResolver` to map raw food fields to nutrients
- track translation details in `InputTrace`
- expand nutrition vector builder with food item support
- test food item resolution logic

## Testing
- `pre-commit run --files rust/Cargo.toml rust/src/lib.rs rust/src/nutrition_vector.rs rust/src/wasm.rs rust/src/food_item_resolver.rs rust/tests/food_resolver.rs schema/food_components.json`

------
https://chatgpt.com/codex/tasks/task_b_6863b017a70083339ca206eeac9dcc3d