### PR TITLE
Add knowledge ingest stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ data/detailed_dii_table_20240606.csv
 rust/target/
 /pkg
 !/docs
+.session_cache/
+logs/

--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ pytest tests/ --cov
   ```
   Only the `.b64` file is committed to avoid binary diffs.
 
+- **Refresh canonical data** by running:
+  ```bash
+  python scripts/refresh_schema_model.py
+  ```
+  Cached results are written to `.session_cache/` for later merging.
+
 ---
 
 ## Validation

--- a/schema/init_seed_from_literature.json
+++ b/schema/init_seed_from_literature.json
@@ -1,0 +1,5 @@
+{
+  "notes": "Initial seed data from published literature.",
+  "created": "2025-07-01T10:24:11Z",
+  "entries": []
+}

--- a/schema/sync_state.lock
+++ b/schema/sync_state.lock
@@ -1,0 +1,4 @@
+{
+  "last_sync": "2025-07-01T10:24:11Z",
+  "status": "initialized"
+}

--- a/scripts/refresh_schema_model.py
+++ b/scripts/refresh_schema_model.py
@@ -1,0 +1,52 @@
+"""Gather domain data and update schema caches.
+
+This script fetches public resources (when network access is available)
+and stores them under `.session_cache/` with a timestamped file name.
+It intentionally keeps implementation light so pre-commit hooks remain fast.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+from pathlib import Path
+
+import requests
+
+CACHE_DIR = Path(".session_cache")
+CACHE_DIR.mkdir(exist_ok=True)
+LOG_DIR = Path("logs/knowledge_sync")
+LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+SOURCES = {
+    "nutriverse/dietaryindex": "https://raw.githubusercontent.com/nutriverse/dietaryindex/main/README.md",
+    # Additional sources can be added here
+}
+
+
+def gather() -> Path:
+    """Collect data from known sources and write to cache."""
+    timestamp = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    payload: dict[str, object] = {"timestamp": timestamp, "sources": {}}
+
+    for name, url in SOURCES.items():
+        try:
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+            payload["sources"][name] = resp.text
+        except Exception as exc:  # noqa: BLE001
+            payload["sources"][name] = f"error: {exc}"
+
+    cache_file = CACHE_DIR / f"canonical_ingest_{timestamp}.json"
+    cache_file.write_text(json.dumps(payload, indent=2))
+    logging.info("Wrote %s", cache_file)
+
+    summary = LOG_DIR / f"{timestamp}_summary.json"
+    summary.write_text(json.dumps({"ingest": cache_file.name}, indent=2))
+    logging.info("Logged summary %s", summary)
+    return cache_file
+
+
+if __name__ == "__main__":
+    gather()


### PR DESCRIPTION
## Summary
- add schema scaffolding for knowledge ingestion
- create a minimal `refresh_schema_model.py` script
- document the refresh step in README
- ignore session cache and logs

## Testing
- `black scripts/refresh_schema_model.py`
- `isort scripts/refresh_schema_model.py`
- `flake8 scripts/refresh_schema_model.py`
- `pre-commit run --all-files` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_6863b6bf64888333b828dcdeffc69915