### PR TITLE
Document ISA and update automation references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,3 +117,10 @@ This phase enforces output validation in the Rust scoring engine and ensures eve
 | ACS2020_V1 | 2 |
 | ACS2020_V2 | 2 |
 | ACS2020_V3 | 2 |
+
+## Intelligent System Agent
+The repository includes a lightweight "Intelligent System Agent" (ISA)
+that records proposed schema updates under `.codex/`.  See
+[docs/ISA_MANIFEST.md](docs/ISA_MANIFEST.md) for details on its scope and
+recent activity.  ISA actions run as part of the pre-commit hook but do
+not persist any background daemon.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,3 +7,9 @@ The project delivers diet-quality scoring directly in the browser. A Rust librar
 Input CSV files are normalized via `compute.mapping.apply_mapping` before validation. Missing required fields cause a hard failure so results never rely on partial or guessed data.
 
 **Directive Status:** INCOMPLETE – enforcement hooks are still under review.
+
+## Intelligent System Agent
+A thin automation layer keeps the schema and contracts in sync with
+external datasets. The agent runs via `pre-commit` and writes proposed
+updates under `.codex/`. Maintainers review these suggestions before
+they are merged.

--- a/docs/ISA_MANIFEST.md
+++ b/docs/ISA_MANIFEST.md
@@ -1,0 +1,15 @@
+# Intelligent System Agent Manifest
+
+This document summarizes the intended behavior of the Intelligent System Agent (ISA).
+The ISA monitors repository activity and aggregates external nutrition data
+into the project's schema files. Its goal is to keep field mappings and
+scoring contracts up to date without manual effort.
+
+The implementation is lightweight. A background script collects new field
+aliases and records proposed changes under `.codex/` so maintainers can
+review them. Pre-commit hooks run these checks automatically.
+
+## Last Update
+
+This file was generated during an automated Codex session to document the
+current ISA scope. No persistent background process is running.

--- a/docs/SCORING_CONTRACTS.md
+++ b/docs/SCORING_CONTRACTS.md
@@ -49,3 +49,8 @@ HCSN files follow the same pattern. Column aliases defined in `schema/hcsn_field
 | `pastry_sweets_servings` | `sugar_g` |
 | `fried_food_servings` | `fast_food_g` |
 | `olive_oil_daily_use` | `mono_fat_g` |
+
+The canonical contract rules consumed by the scoring engine are stored in
+[`schema/contracts.json`](../schema/contracts.json). The Intelligent
+System Agent writes any proposed adjustments to `.codex/contracts/` for
+maintainer review.

--- a/scripts/refresh_schema_model.py
+++ b/scripts/refresh_schema_model.py
@@ -20,7 +20,9 @@ LOG_DIR = Path("logs/knowledge_sync")
 LOG_DIR.mkdir(parents=True, exist_ok=True)
 
 SOURCES = {
-    "nutriverse/dietaryindex": "https://raw.githubusercontent.com/nutriverse/dietaryindex/main/README.md",
+    "nutriverse/dietaryindex": (
+        "https://raw.githubusercontent.com/nutriverse/" "dietaryindex/main/README.md"
+    ),
     # Additional sources can be added here
 }
 

--- a/scripts/review_unmapped.py
+++ b/scripts/review_unmapped.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-#!/usr/bin/env python3
 """Review unmapped field log and suggest updates to food_components.json."""
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- add new `docs/ISA_MANIFEST.md`
- describe ISA in `AGENTS.md`
- note automation in `ARCHITECTURE.md`
- clarify canonical contracts in `SCORING_CONTRACTS.md`
- fix flake8 issues in scripts

## Testing
- `pre-commit run --files AGENTS.md docs/ARCHITECTURE.md docs/SCORING_CONTRACTS.md scripts/refresh_schema_model.py scripts/review_unmapped.py docs/ISA_MANIFEST.md`

------
https://chatgpt.com/codex/tasks/task_b_6863babbd5fc8333822f9d7bf9dc70ad