### PR TITLE
Add helper for DII header casing

### DIFF
--- a/compute/mapping.py
+++ b/compute/mapping.py
@@ -62,6 +62,13 @@ USDA_DII_MAP: dict[str, str] = {
     "VITE": "Vitamin E",
 }
 
+# Column case fixes for DII validation datasets
+DII_CASE_MAP: dict[str, str] = {
+    "vitamin B12": "Vitamin B12",
+    "vitamin B6": "Vitamin B6",
+    "Thyme_oregano": "Thyme/oregano",
+}
+
 # ---------------------------------------------------------------------------
 
 
@@ -80,3 +87,8 @@ def apply_mapping(df: pd.DataFrame, mapping: Mapping[str, str]) -> pd.DataFrame:
         logging.info("Columns left unmapped: %s", sorted(unmapped))
 
     return df.rename(columns=rename_map)
+
+
+def normalize_dii_headers(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalize common DII column casing variations."""
+    return apply_mapping(df, DII_CASE_MAP)

--- a/tests/test_validation_dii_extra.py
+++ b/tests/test_validation_dii_extra.py
@@ -2,17 +2,12 @@ import pandas as pd
 import pytest
 
 from compute.dii import calculate_dii, get_dii_parameters
+from compute.mapping import normalize_dii_headers
 
 
 def test_dii_matches_publication_validation():
     df = pd.read_csv("data/DII_validation_result.csv")
-    df = df.rename(
-        columns={
-            "vitamin B12": "Vitamin B12",
-            "vitamin B6": "Vitamin B6",
-            "Thyme_oregano": "Thyme/oregano",
-        }
-    )
+    df = normalize_dii_headers(df)
     cols = [p["name"] for p in get_dii_parameters()]
     result = calculate_dii(df[cols])
     assert pytest.approx(result.tolist(), rel=1e-3, abs=1e-3) == df["DII_ALL"].tolist()


### PR DESCRIPTION
## Summary
- normalize common DII columns with new `normalize_dii_headers`
- use helper in DII validation test

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_b_68642cef7bf083338b5bb3e7e2b7878b