### PR TITLE
Improve ISA refresh and add unit tests

### DIFF
--- a/.codex/session_logs/notes.txt
+++ b/.codex/session_logs/notes.txt
@@ -1,0 +1,1 @@
+Added unit conversion and API endpoint tests. Hook now refreshes ISA_STATE automatically.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,11 @@ repos:
 
   - repo: local
     hooks:
+      - id: refresh-isa-state
+        name: refresh ISA_STATE
+        entry: python scripts/refresh_isa_state.py
+        language: system
+        pass_filenames: false
       - id: isa-state
         name: validate ISA_STATE
         entry: python scripts/check_isa_state.py

--- a/ISA_STATE.json
+++ b/ISA_STATE.json
@@ -2,5 +2,5 @@
   "observed_changes": [],
   "recent_mappings": [],
   "scoring_priority": {},
-  "timestamp": "2025-07-01T12:34:09Z"
+  "timestamp": "2025-07-01T19:20:17Z"
 }

--- a/scripts/isa_state_pipeline.py
+++ b/scripts/isa_state_pipeline.py
@@ -62,10 +62,15 @@ def compute_state() -> tuple[Dict[str, Any], Dict[str, Any]]:
 
 
 def update_state() -> None:
-    """Write the computed ISA state to disk."""
+    """Write the computed ISA state to disk if it changed."""
     state, todo = compute_state()
-    save_json(STATE_FILE, state)
-    save_json(TODO_FILE, todo)
+    current_state = load_json(STATE_FILE)
+    current_todo = load_json(TODO_FILE)
+    state_no_time = {k: v for k, v in state.items() if k != "timestamp"}
+    cur_no_time = {k: v for k, v in current_state.items() if k != "timestamp"}
+    if state_no_time != cur_no_time or todo != current_todo:
+        save_json(STATE_FILE, state)
+        save_json(TODO_FILE, todo)
 
 
 def run_background() -> None:

--- a/tests/test_api_score_basic.py
+++ b/tests/test_api_score_basic.py
@@ -1,0 +1,24 @@
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+from fastapi.testclient import TestClient
+
+from compute.api import app
+from compute.dii import DII_PARAMETER_KEYS
+
+client = TestClient(app)
+
+
+def test_score_endpoint_roundtrip(tmp_path):
+    df = pd.DataFrame({key: [1.0, 2.0] for key in DII_PARAMETER_KEYS})
+    file = tmp_path / "t.csv"
+    df.to_csv(file, index=False)
+    resp = client.post(
+        "/score?indices=DII", files={"file": ("t.csv", file.read_bytes(), "text/csv")}
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "filename" in data
+    out = Path(tempfile.gettempdir()) / data["filename"]
+    assert out.exists()

--- a/tests/test_unit_conversion.py
+++ b/tests/test_unit_conversion.py
@@ -1,0 +1,34 @@
+import pandas as pd
+import pytest
+
+from compute.unit_conversion import (
+    convert_to_canonical_units,
+    infer_units,
+    rename_for_scoring,
+)
+
+
+def test_infer_and_convert_units():
+    df = pd.DataFrame(
+        {
+            "energy_kj": [418.4],  # 100 kcal
+            "vitamin_c_mcg": [1000000],  # 1000 mg
+            "protein_g": [10],
+        }
+    )
+    units = infer_units(df)
+    assert units["energy"] == "kj"
+    assert units["vitamin_c"] == "mcg"
+    df = convert_to_canonical_units(df, units)
+    df = rename_for_scoring(df)
+    assert df["energy_kcal"].iloc[0] == pytest.approx(100)
+    assert df["vitamin_c_mg"].iloc[0] == pytest.approx(1000)
+    assert "protein_g" in df.columns
+
+
+def test_default_unit_suffix_added():
+    df = pd.DataFrame({"energy": [50], "protein": [5]})
+    units = infer_units(df)
+    assert units["energy"] == "kcal"
+    df = rename_for_scoring(df)
+    assert set(df.columns) == {"energy_kcal", "protein_g"}


### PR DESCRIPTION
## Summary
- auto refresh ISA_STATE in pre-commit
- avoid timestamp churn by updating state only on real changes
- test API score endpoint and unit conversion logic
- store session notes

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_b_686432a39e648333ab817a7346489563